### PR TITLE
Ignore optimize* and debug* in subdirectories of sw4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,9 @@ build/
 
 *.synctex.gz
 
-optimize/
+*/optimize*/
 
-debug/
+*/debug*/
 
 *.o
 


### PR DESCRIPTION
sw4lite creates directories depending on hostnames like optimize_ray
optimize_surface etc. Ignore them.