### PR TITLE
Pytest refactoring cliparser

### DIFF
--- a/pytest/test_sw4.py
+++ b/pytest/test_sw4.py
@@ -297,19 +297,12 @@ if __name__ == "__main__":
 
     parser = create_parser()
     args = parser.parse_args()
-    if args.verbose:
-        #print("verbose mode enabled")
-        verbose=True
-    if args.level:
-        #print("Testing level specified=", args.level)
-        testing_level=args.level
-    if args.mpitasks:
-        #print("MPI-tasks specified=", args.mpitasks)
-        if args.mpitasks > 0: mpi_tasks=args.mpitasks
-    if args.sw4_exe_dir:
-        #print("sw4_exe_dir specified=", args.sw4_exe_dir)
-        sw4_exe_dir=args.sw4_exe_dir
 
-    if not main_test(sw4_exe_dir, testing_level, mpi_tasks, verbose):
+    if not main_test(
+        args.sw4_exe_dir,
+        args.level,
+        args.mpitasks,
+            args.verbose):
+
         print("test_sw4 was unsuccessful")
 

--- a/pytest/test_sw4.py
+++ b/pytest/test_sw4.py
@@ -252,19 +252,50 @@ def main_test(sw4_exe_dir="optimize", testing_level=0, mpi_tasks=0, verbose=Fals
     return True
     
 #------------------------------------------------
+def create_parser():
+    parser = argparse.ArgumentParser(
+        description=None,
+        epilog=None,
+    )
+
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="increase output verbosity",
+    )
+
+    parser.add_argument(
+        "-l",
+        "--level",
+        type=int,
+        choices=[0, 1, 2],
+        default=0,
+        help="testing level",
+    )
+
+    parser.add_argument(
+        "-m",
+        "--mpitasks",
+        type=int,
+        default=0,
+        help="number of mpi tasks",
+    )
+
+    parser.add_argument(
+        "-d",
+        "--sw4_exe_dir",
+        default="optimize",
+        help="name of directory for sw4 executable",
+    )
+
+    return parser
+
+#------------------------------------------------
 if __name__ == "__main__":
     assert sys.version_info >= (3,5) # subprocess.run(...) requires 3.5
-    # default arguments
-    testing_level=0
-    verbose=False
-    mpi_tasks=0 # machine dependent default
 
-    parser=argparse.ArgumentParser()
-    parser.add_argument("-v", "--verbose", help="increase output verbosity", action="store_true")
-    parser.add_argument("-l", "--level", type=int, choices=[0, 1, 2], 
-                        help="testing level")
-    parser.add_argument("-m", "--mpitasks", type=int, help="number of mpi tasks")
-    parser.add_argument("-d", "--sw4_exe_dir", help="name of directory for sw4 executable", default="optimize")
+    parser = create_parser()
     args = parser.parse_args()
     if args.verbose:
         #print("verbose mode enabled")

--- a/pytest/test_sw4.py
+++ b/pytest/test_sw4.py
@@ -271,7 +271,7 @@ def create_parser():
         type=int,
         choices=[0, 1, 2],
         default=0,
-        help="testing level",
+        help="testing level (default: 0)",
     )
 
     parser.add_argument(
@@ -279,14 +279,14 @@ def create_parser():
         "--mpitasks",
         type=int,
         default=0,
-        help="number of mpi tasks",
+        help="number of mpi tasks. if less than or equal to 0, value will be set to a machine dependent value (default: 0)",
     )
 
     parser.add_argument(
         "-d",
         "--sw4_exe_dir",
         default="optimize",
-        help="name of directory for sw4 executable",
+        help="name of directory that contains sw4 executable (default: 'optimize')",
     )
 
     return parser


### PR DESCRIPTION
- Move parser creation to a function
- Use parser arguments directly
- Add more information in parser help strings

The case of user input for `mpitasks` is now handled slightly differently, but functionally the same. It used to stay zero if the user input a negative number, but is now given to `main_test(...)` as the unchanged user value. However, `main_test(...)` only uses `mpitasks` to call `guess_mpi_cmd(...)` and `guess_mpi_cmd(...)` treats a zero or negative `mpitasks` identically.

Similarly, `sw4_exe_dir` is now handled slightly differently, in that if the user deliberately sets the flag to the empty string, `main_test(...)` will now receive `sw4_exe_dir` as the empty string. Previously, the script would crash with `NameError: name 'sw4_exe_dir' is not defined`.

Let me know if I should make a Github issue to better explain the crash.