### PR TITLE
Create Dockerfile for SW4 build environment

### DIFF
--- a/docker/sw4-buildenv-bionic/Dockerfile
+++ b/docker/sw4-buildenv-bionic/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:18.04
+
+RUN apt update && \
+  DEBIAN_FRONTEND='noninteractive' \
+  DEBCONF_NONINTERACTIVE_SEEN='true' \
+  apt install --yes \
+    build-essential \
+    cmake \
+    gfortran \
+    libblas-dev \
+    liblapack-dev \
+    libmpich-dev \
+    libproj-dev \
+    python3

--- a/docker/sw4-buildenv-bionic/README.md
+++ b/docker/sw4-buildenv-bionic/README.md
@@ -1,0 +1,1 @@
+Build environment for SW4 using the Ubuntu Bionic (18.04) Docker container.


### PR DESCRIPTION
This Dockerfile will be used to create a build environment for SW4. Dockerfiles make it easy to be explicit about environment requirements, and containers are easily sandboxed, ensuring useful testing results. Having the Dockerfile in the repository makes it simple to update, allows developers and users to be sure about dependencies, and means that we can use CIG's DockerHub [page](https://dockerhub.com/u/geodynamics) to automatically build and distribute the container.

CIG's Jenkins server can be found at https://jenkins.geodynamics.org.