### PR TITLE
Fix two bugs in sw4mopt related code

### DIFF
--- a/src/MaterialParameterization.C
+++ b/src/MaterialParameterization.C
@@ -204,7 +204,8 @@ void  MaterialParameterization::get_regularizer( int nmd, double* xmd, int nms, 
 		      double* sfd, double* sfs, bool compute_derivative, 
 		      double* dmfd_reg, double* dmfs_reg )
 {
-   if( regcoeff == 0 )
+   mf_reg = 0;
+   if( fabs(regcoeff) < 1e-6 )
       return;
 
 // Default, Tikhonov regularizing term:

--- a/src/TimeSeries.C
+++ b/src/TimeSeries.C
@@ -1736,7 +1736,7 @@ float_sw4 TimeSeries::misfit( TimeSeries& observed, TimeSeries* diff,
 
 
 	 float_sw4 t  = m_t0 + m_shift + i*m_dt;
-	 float_sw4 ir = (t-t0fr)/dtfr;
+	 float_sw4 ir = round((t-t0fr)/dtfr);
 	 int ie   = static_cast<int>(ir);
 	 //	 int mmin = ie-order/2+1;
 	 //	 int mmax = ie+order/2;
@@ -1771,7 +1771,7 @@ float_sw4 TimeSeries::misfit( TimeSeries& observed, TimeSeries* diff,
 
 	 // If too far past the end of observed, set to zero.
 	 //	 if( ie > nfrsteps + order/2 )
-         if( ie > nfrsteps+1 )
+         if( ie > nfrsteps-1 )
 	 {
 	    mf[0]   = mf[1]   = mf[2]   = 0;
             dmf[0]  = dmf[1]  = dmf[2]  = 0;
@@ -1814,8 +1814,8 @@ float_sw4 TimeSeries::misfit( TimeSeries& observed, TimeSeries* diff,
 	    }
 	    else if( ie > nfrsteps-3 )
 	    {
-	       mmin = nfrsteps-4;
-	       mmax = nfrsteps;
+	       mmin = nfrsteps-5;
+	       mmax = nfrsteps-1;
 	       ai   = ir - (mmin+2);
 	       getwgh5( ai, wgh, dwgh, ddwgh );
 	    }


### PR DESCRIPTION
1. get_regularizer() needs to set mf_reg to zero before returning and not use direct comparison between regcoeff (double) and 0.

2. In misfit(), there are several places that calculate the index max values off by 1, which leads to buffer overflow in the for( int m = mmin ; m <= mmax ; m++ ) loop at line 1830.