### PR TITLE
Fix for geodynbc with mesh refinement (do not set h from whi file)

### DIFF
--- a/src/parseInputFile.C
+++ b/src/parseInputFile.C
@@ -891,7 +891,9 @@ void EW::processGrid(char* buffer) {
       proj0 << " +lat_0=" << mLatOrigin;
     }
   }
-
+  
+  // Setting h from whi file stepsize is problematic for mesh refinement  
+  /*
   float_sw4 cubelen, zcubelen;
   if (m_geodynbc_found) {
     // Set SW4 grid spacing based on Geodyn cube data
@@ -1079,6 +1081,7 @@ void EW::processGrid(char* buffer) {
       }
     }
   }
+  */
   if (!m_doubly_periodic) {
     if (proc_zero() && mVerbose >= 3)
       printf("**** Setting up the grid for a non-periodic problem\n");


### PR DESCRIPTION
The code to parse the input file did not consider mesh refinement such that stepsize in whi file may not be equal to h in grid[0]. This caused problems when trying to set h from whi file. But this is never done anyway, so removing it should have no effect. The complication was that the section in parseInputFile.C that sets h from the whi file (geodynbc) also calculates the origin, which is necessary for the geodyncbc time stepping calculations. So, I had to introduce new variable to keep the geodynbc stepsize for the origin calculation.