### PR TITLE
Tang/imagehdf5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 #-----------------------------------------------------------------------
 # Usage:
 #   Default is: debug=no prec=double openmp=yes hdf5=no fftw=no
-# make sw4     [debug=yes/no] [prec=single/double] [openmp=yes/no] [hdf5=yes/no] [fftw=yes/no]
-# make sw4mopt [debug=yes/no] [prec=single/double] [openmp=yes/no] [hdf5=yes/no] [fftw=yes/no]
+# make sw4     [debug=yes/no] [prec=single/double] [openmp=yes/no] [hdf5=yes/no] [zfp=yes/no] [fftw=yes/no]
+# make sw4mopt [debug=yes/no] [prec=single/double] [openmp=yes/no] [hdf5=yes/no] [zfp=yes/no] [fftw=yes/no]
 #
 # This Makefile asumes that the following environmental variables have been assigned,
 # see note below.
@@ -13,6 +13,8 @@
 #
 # SW4ROOT = path to third party libraries (used when etree=yes and proj=yes). 
 # HDF5ROOT = path to hdf5 library and include files (used when hdf5=yes).
+# H5ZROOT = path to H5Z-ZFP library and include files (used when zfp=yes).
+# ZFPROOT = path to ZFP library and include files (used when zfp=yes).
 # FFTWROOT = path to fftw library and include files (used when fftw=yes).
 # Note: third party libraries should have include files in $(SW4ROOT)/include, libraries in $(SW4ROOT)/lib
 # Note: HDF5ROOT and FFTWROOT can be left undefined if these libraries are 
@@ -190,6 +192,11 @@ ifeq ($(hdf5),yes)
    # PROVIDE HDF5ROOT in configs/make.xyz, e.g.
    CXXFLAGS  += -I$(HDF5ROOT)/include -DUSE_HDF5
    EXTRA_LINK_FLAGS += -L$(HDF5ROOT)/lib -lhdf5_hl -lhdf5
+endif
+
+ifeq ($(zfp),yes)
+   CXXFLAGS  += -I$(H5ZROOT)/include -I$(ZFPROOT)/include -DUSE_ZFP
+   EXTRA_LINK_FLAGS += -L$(H5ZROOT)/lib -L$(ZFPROOT)/lib -lh5zzfp -lzfp 
 endif
 
 ifdef EXTRA_LINK_FLAGS

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 #-----------------------------------------------------------------------
 # Usage:
-#   Default is: debug=no profile=no prec=double openmp=yes hdf5=no fftw=no
-# make sw4     [debug=yes/no] [profile=yes/no] [prec=single/double] [openmp=yes/no] [hdf5=yes/no] [zfp=yes/no] [sz=yes/no] [fftw=yes/no]
-# make sw4mopt [debug=yes/no] [profile=yes/no] [prec=single/double] [openmp=yes/no] [hdf5=yes/no] [zfp=yes/no] [sz=yes/no] [fftw=yes/no]
+#   Default is: debug=no proj=yes profile=no prec=double openmp=yes hdf5=no fftw=no
+# make sw4     [debug=yes/no] [proj=yes/no] [profile=yes/no] [prec=single/double] [openmp=yes/no] [hdf5=yes/no] [zfp=yes/no] [sz=yes/no] [fftw=yes/no]
+# make sw4mopt [debug=yes/no] [proj=yes/no] [profile=yes/no] [prec=single/double] [openmp=yes/no] [hdf5=yes/no] [zfp=yes/no] [sz=yes/no] [fftw=yes/no]
 #
 # This Makefile asumes that the following environmental variables have been assigned,
 # see note below.
@@ -60,6 +60,12 @@ else
 # AP (160419) Note that cmake uses -O3 instead of -O for CXX and C
    CXXFLAGS = -O3 -I../src -std=c++11
    CFLAGS   = -O3 
+endif
+
+ifeq ($(proj),no)
+    proj := "no"
+else
+    proj := "yes"
 endif
 
 fullpath := $(shell pwd)

--- a/pytest/test_sw4.py
+++ b/pytest/test_sw4.py
@@ -251,10 +251,11 @@ def main_test(sw4_exe_dir="optimize_mp", pytest_dir ="none", testing_level=0, mp
     elif testing_level == 2:
         num_meshes =[1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 1, 3, 1, 1]
 
+    
     print("Running all tests for level", testing_level, "...")
     # run all tests
     for qq in range(len(all_dirs)):
-
+   
         test_dir = all_dirs[qq]
         base_case = all_cases[qq]
         result_file = all_results[qq]
@@ -381,77 +382,7 @@ def main_test(sw4_exe_dir="optimize_mp", pytest_dir ="none", testing_level=0, mp
                 
             # end for qq in all_dirs[qq]
 
-                sw4_stdout_file.close()
-                sw4_stderr_file.close()
-
-                # status = os.system(run_cmd)
-                # if status!=0:
-                #     print('ERROR: Test', test_case, ': sw4 returned non-zero exit status=', status, 'aborting test')
-                #     print('run_cmd=', run_cmd)
-                #     print("DID YOU USE THE CORRECT SW4 EXECUTABLE? (SPECIFY DIRECTORY WITH -d OPTION)")
-                #     return False # bail out
-
-                if status.returncode!=0:
-                    print('ERROR: Test', test_case, ': sw4 returned non-zero exit status=', status.returncode, 'aborting test')
-                    print('run_cmd=', run_cmd)
-                    print("DID YOU USE THE CORRECT SW4 EXECUTABLE? (SPECIFY DIRECTORY WITH -d OPTION)")
-                    return False # bail out
-
-
-                ref_result = reference_dir + sep + test_dir + sep + case_dir + sep + result_file
-                #print('Test #', num_test, 'output dirs: local case_dir =', case_dir, 'ref_result =', ref_result)
-
-
-                if result_file == 'hdf5.log':
-                    import verify_hdf5
-                    success = True
-                    sw4_stdout_file = open(case_dir + '.out', 'r')
-                    for line in sw4_stdout_file:
-                        if "Error" in line or "not compiled with HDF5" in line or "without sw4 compiled with HDF5" in line:
-                            success = False
-                            print('  SW4 is not compiled with HDF5 library!')
-                            break;
-                    sw4_stdout_file.close()
-                    if success == True:
-                        success = verify_hdf5.verify(pytest_dir, 1e-5)
-                    if success == False:
-                        # print('HDF5 test failed! (disable HDF5 test with -n option)')
-                        nohdf5 = True
-                elif result_file == 'hdf5-sfile.log':
-                    import verify_hdf5
-                    success = True
-                    sw4_stdout_file = open(case_dir + '.out', 'r')
-                    for line in sw4_stdout_file:
-                        if "Error" in line or "not compiled with HDF5" in line or "without sw4 compiled with HDF5" in line:
-                            success = False
-                            print('  SW4 is not compiled with HDF5 library!')
-                            break;
-                    sw4_stdout_file.close()
-                    if success == True:
-                        success = verify_hdf5.verify_sac_image(pytest_dir, 1e-5)
-                    if success == False:
-                        # print('HDF5 test failed! (disable HDF5 test with -n option)')
-                        nohdf5 = True
-
-                elif result_file == 'energy.log':
-                    success = compare_energy(case_dir + sep + result_file, 1e-10, verbose)
-                else:
-                    # compare output with reference result (always compare the last line)
-                    success = compare_one_line(ref_result , case_dir + sep + result_file, 1e-5, 1e-10, -1, verbose)
-                    if success and 'attenuation' in test_dir:
-                        # also compare the 3rd last line in the files
-                        success = compare_one_line(ref_result , case_dir + sep + result_file, 1e-5, 1e-10, -3, verbose)
-
-                if success:        
-                    print('Test #', num_test, "Input file:", test_case, 'PASSED')
-                    num_pass += 1
-                else:
-                    print('Test #', num_test, "Input file:", test_case, 'FAILED')
-                    num_fail += 1
-                
-            # end for qq in all_dirs[qq]
-
-            os.chdir('..') # change back to the parent directory
+        os.chdir('..') # change back to the parent directory
 
     # end for all cases in the test_dir
     print('Out of', num_test, 'tests,', num_fail, 'failed,', num_pass, 'passed, and', num_skip, 'skipped')

--- a/src/ESSI3D.C
+++ b/src/ESSI3D.C
@@ -49,6 +49,7 @@ ESSI3D* ESSI3D::nil=static_cast<ESSI3D*>(0);
 ESSI3D::ESSI3D( EW* a_ew,
     const std::string& filePrefix,
     int dumpInterval,
+    int bufferInterval,
     float_sw4 coordBox[6],
     float_sw4 depth,
     int precision,
@@ -64,6 +65,8 @@ ESSI3D::ESSI3D( EW* a_ew,
       m_hdf5_time(0),
       m_cycle(-1),
       m_dumpInterval(-1),
+      m_bufferInterval(1),
+      m_nbufstep(0),
       mDepth(depth),
       m_precision(precision),
       m_ZFPmode(ZFPmode),
@@ -75,6 +78,7 @@ ESSI3D::ESSI3D( EW* a_ew,
     mCoordBox[d] = coordBox[d];
 
   set_dump_interval(dumpInterval);
+  set_buffer_interval(bufferInterval);
 }
 
 //-----------------------------------------------------------------------
@@ -97,12 +101,18 @@ void ESSI3D::set_ntimestep(int ntimestep)
     m_ntimestep = ntimestep;
 }
 
-
 //-----------------------------------------------------------------------
 void ESSI3D::set_dump_interval( int a_dumpInterval )
 {
   if (a_dumpInterval > 0)
     m_dumpInterval = a_dumpInterval;
+}
+
+//-----------------------------------------------------------------------
+void ESSI3D::set_buffer_interval( int a_bufferInterval )
+{
+  if (a_bufferInterval > 0)
+    m_bufferInterval = a_bufferInterval;
 }
 
 //-----------------------------------------------------------------------
@@ -180,6 +190,8 @@ void ESSI3D::setup( )
   {
     size_t npts = ((size_t)(mWindow[1] - mWindow[0]) + 1)*
       ( (mWindow[3] - mWindow[2]) + 1)* ( (mWindow[5] - mWindow[4]) + 1);
+    npts *= m_bufferInterval;
+
     if (m_precision == 4) 
       m_floatField = new float[npts];
     else if (m_precision == 8) 
@@ -267,7 +279,7 @@ void ESSI3D::force_write_image( float_sw4 a_time, int a_cycle,
 }
 
 //-----------------------------------------------------------------------
-void ESSI3D::compute_image( Sarray& a_A, int a_comp )
+void ESSI3D::compute_image( Sarray& a_A, int a_comp, int cycle )
 {
   int g=mEW->mNumberOfGrids-1;
 
@@ -282,9 +294,10 @@ void ESSI3D::compute_image( Sarray& a_A, int a_comp )
 
   // int niw = (mWindow[1]-mWindow[0])+1;
   // int nijw=niw*((mWindow[3]-mWindow[2])+1);
-  int nkw = (mWindow[5]-mWindow[4])+1;
-  int njkw=nkw*((mWindow[3]-mWindow[2])+1);
-  const int c  = a_comp+1; // why comp+1?
+  size_t nkw = (mWindow[5]-mWindow[4])+1;
+  size_t njkw=nkw*((mWindow[3]-mWindow[2])+1);
+  size_t nijkw=njkw*((mWindow[1]-mWindow[0])+1);
+  const int c  = a_comp+1; 
 #pragma omp parallel for
   for( int k=mWindow[4] ; k <= mWindow[5] ; k++ )
   for( int j=mWindow[2] ; j <= mWindow[3] ; j++ )
@@ -293,11 +306,15 @@ void ESSI3D::compute_image( Sarray& a_A, int a_comp )
     // HDF5 expects k major, then j, i
     // size_t ind = (i-mWindow[0])+niw*(j-mWindow[2])+nijw*(k-mWindow[4]);
     size_t ind = njkw*(i-mWindow[0])+nkw*(j-mWindow[2])+(k-mWindow[4]);
+    ind += m_nbufstep * nijkw;
     if (m_precision == 4) 
       m_floatField[ind]= (float) a_A(c,i,j,k);
     else if (m_precision == 8) 
       m_doubleField[ind]= (double) a_A(c,i,j,k);
   }
+
+  m_nbufstep++;
+  m_nbufstep %= m_bufferInterval;
 }
 
 //-----------------------------------------------------------------------
@@ -342,27 +359,27 @@ void ESSI3D::open_vel_file( int a_cycle, std::string& a_path,
   // Parameters for extendible dataset
   const int num_dims = 3 + 1; // 3 space + 1 time that will be extendible
   hsize_t dims[num_dims]={0,0,0,0};
-  hsize_t slice_dims[num_dims];
-  hsize_t block_dims[num_dims];
-  hsize_t global_dims[num_dims];
+  /* hsize_t slice_dims[num_dims]; */
+  /* hsize_t block_dims[num_dims]; */
+  /* hsize_t global_dims[num_dims]; */
 
   int g = mEW->mNumberOfGrids-1;
   int window[6], global[3];
   for (int d=0; d < 3; d++)
   {
     dims[d] = mWindow[2*d+1] - mWindow[2*d] + 1;
-    slice_dims[d] = dims[d];
-    block_dims[d] = dims[d];
-    global_dims[d] = mGlobalDims[2*d+1] - mGlobalDims[2*d] + 1;
+    /* slice_dims[d] = dims[d]; */
+    /* block_dims[d] = dims[d]; */
+    /* global_dims[d] = mGlobalDims[2*d+1] - mGlobalDims[2*d] + 1; */
 
     window[2*d] = (m_ihavearray) ? (mWindow[2*d] - mGlobalDims[2*d]) : 0;
     window[2*d+1] = (m_ihavearray) ? (mWindow[2*d+1] - mGlobalDims[2*d]) : -1;
     global[d] = mGlobalDims[2*d+1] - mGlobalDims[2*d] + 1;
   }
-  slice_dims[0] = 1; // Make sure we're chunking on slices
-  slice_dims[num_dims-1] = 1; // 1 time step per write
-  block_dims[num_dims-1] = 1; // 1 time step per write
-  global_dims[num_dims-1] = 1; // 1 time step per write
+  /* slice_dims[0] = 1; // Make sure we're chunking on slices */
+  /* slice_dims[num_dims-1] = 1; // 1 time step per write */
+  /* block_dims[num_dims-1] = 1; // 1 time step per write */
+  /* global_dims[num_dims-1] = 1; // 1 time step per write */
 
   /* // Just to see what's being copied correctly */
   /* for( int i=0 ; i < dims[0]; i++ ) */
@@ -413,11 +430,12 @@ void ESSI3D::open_vel_file( int a_cycle, std::string& a_path,
   // Write z coodinates if necesito
   if (mEW->topographyExists())
   {
-    compute_image(a_Z, 0);
+    compute_image(a_Z, 0, 0);
     if (m_precision == 4) 
       m_hdf5helper->write_topo(m_floatField);
     else if (m_precision == 8) 
       m_hdf5helper->write_topo(m_doubleField);
+    m_nbufstep = 0;
   }
 
   /*
@@ -428,13 +446,13 @@ void ESSI3D::open_vel_file( int a_cycle, std::string& a_path,
   if (m_dumpInterval > 0) {
     int nstep = m_ntimestep / m_dumpInterval;
     if (m_ZFPmode > 0) 
-      m_hdf5helper->init_write_vel_compression(nstep, m_ZFPmode, m_ZFPpar);
+      m_hdf5helper->init_write_vel_compression(nstep, m_ZFPmode, m_ZFPpar, m_dumpInterval);
     else
       m_hdf5helper->init_write_vel(nstep);
   }
   else{
     if (m_ZFPmode > 0) 
-      m_hdf5helper->init_write_vel_compression(m_ntimestep, m_ZFPmode, m_ZFPpar);
+      m_hdf5helper->init_write_vel_compression(m_ntimestep, m_ZFPmode, m_ZFPpar, m_dumpInterval);
     else
       m_hdf5helper->init_write_vel(m_ntimestep);
   }
@@ -464,18 +482,21 @@ void ESSI3D::write_image_hdf5( int cycle, std::string &path, float_sw4 t,
   int g = mEW->mNumberOfGrids-1;
 
   for (int i = 0; i < 3; i++) {
-    compute_image(a_U[g], i);
-    if (m_ZFPmode > 0) {
-      if (m_precision == 4) 
-        m_hdf5helper->write_vel_compression((void*)m_floatField, i, cycle);
-      else if (m_precision == 8) 
-        m_hdf5helper->write_vel_compression((void*)m_doubleField, i, cycle);
-    }
-    else {
-      if (m_precision == 4) 
-        m_hdf5helper->write_vel((void*)m_floatField, i, cycle);
-      else if (m_precision == 8) 
-        m_hdf5helper->write_vel((void*)m_doubleField, i, cycle);
+    compute_image(a_U[g], i, cycle);
+    if (cycle > 0 && (m_nbufstep == m_bufferInterval || cycle == m_ntimestep-1)) {
+      if (m_ZFPmode > 0) {
+        if (m_precision == 4) 
+          m_hdf5helper->write_vel_compression((void*)m_floatField, i, cycle, m_nbufstep);
+        else if (m_precision == 8) 
+          m_hdf5helper->write_vel_compression((void*)m_doubleField, i, cycle, m_nbufstep);
+      }
+      else {
+        if (m_precision == 4) 
+          m_hdf5helper->write_vel((void*)m_floatField, i, cycle, m_nbufstep);
+        else if (m_precision == 8) 
+          m_hdf5helper->write_vel((void*)m_doubleField, i, cycle, m_nbufstep);
+      }
+      m_nbufstep = 0;
     }
   }
 

--- a/src/ESSI3D.C
+++ b/src/ESSI3D.C
@@ -462,15 +462,19 @@ void ESSI3D::open_vel_file( int a_cycle, std::string& a_path,
   if (m_dumpInterval > 0) {
     int nstep = (int)ceil(m_ntimestep / m_dumpInterval);
     if (m_ZFPmode > 0) 
-      m_hdf5helper->init_write_vel_compression(nstep, m_ZFPmode, m_ZFPpar, m_bufferInterval);
+      m_hdf5helper->init_write_vel(nstep, m_ZFPmode, m_ZFPpar, m_bufferInterval);
+      /* m_hdf5helper->init_write_vel_compression(nstep, m_ZFPmode, m_ZFPpar, m_bufferInterval); */
     else
-      m_hdf5helper->init_write_vel(nstep);
+      /* m_hdf5helper->init_write_vel(nstep); */
+      m_hdf5helper->init_write_vel(nstep, 0, 0.0, m_bufferInterval);
   }
   else{
     if (m_ZFPmode > 0) 
-      m_hdf5helper->init_write_vel_compression(m_ntimestep, m_ZFPmode, m_ZFPpar, m_bufferInterval);
+      m_hdf5helper->init_write_vel(m_ntimestep, m_ZFPmode, m_ZFPpar, m_bufferInterval);
+      /* m_hdf5helper->init_write_vel_compression(m_ntimestep, m_ZFPmode, m_ZFPpar, m_bufferInterval); */
     else
-      m_hdf5helper->init_write_vel(m_ntimestep);
+      /* m_hdf5helper->init_write_vel(m_ntimestep); */
+      m_hdf5helper->init_write_vel(m_ntimestep, 0, 0.0, m_bufferInterval);
   }
   m_hdf5_time += (MPI_Wtime()-hdf5_time);
 
@@ -498,6 +502,8 @@ void ESSI3D::write_image_hdf5( int cycle, std::string &path, float_sw4 t,
   int g = mEW->mNumberOfGrids-1;
   int doWrite = 0;
   int myRank;
+  bool debug = false;
+  /* debug = true; */
 
   MPI_Comm_rank(MPI_COMM_WORLD, &myRank);
 
@@ -522,7 +528,8 @@ void ESSI3D::write_image_hdf5( int cycle, std::string &path, float_sw4 t,
     fprintf(stderr, "Error with essioutput write_image_hdf5, not all variables are written correctly!\n");
 
   if (doWrite == 3) {
-    printf("Rank %d: write_image_hdf5 cycle=%d/%d, m_nbufstep=%d\n", myRank, cycle, m_ntimestep, m_nbufstep);
+    if (debug) 
+      fprintf(stderr, "Rank %d: write_image_hdf5 cycle=%d/%d, m_nbufstep=%d\n", myRank, cycle, m_ntimestep, m_nbufstep);
     m_nbufstep = 0;
   }
 }

--- a/src/ESSI3D.C
+++ b/src/ESSI3D.C
@@ -53,8 +53,8 @@ ESSI3D::ESSI3D( EW* a_ew,
     float_sw4 coordBox[6],
     float_sw4 depth,
     int precision,
-    int ZFPmode,
-    double ZFPpar):
+    int compressionMode,
+    double compressionPar):
       mEW(a_ew),
       mFilePrefix(filePrefix),
       mFileName(""),
@@ -69,8 +69,8 @@ ESSI3D::ESSI3D( EW* a_ew,
       m_nbufstep(0),
       mDepth(depth),
       m_precision(precision),
-      m_ZFPmode(ZFPmode),
-      m_ZFPpar(ZFPpar),
+      m_compressionMode(compressionMode),
+      m_compressionPar(compressionPar),
       m_hdf5helper(NULL)
 {
   // volimage subdomain x,y corner coordinates
@@ -461,17 +461,17 @@ void ESSI3D::open_vel_file( int a_cycle, std::string& a_path,
 
   if (m_dumpInterval > 0) {
     int nstep = (int)ceil(m_ntimestep / m_dumpInterval);
-    if (m_ZFPmode > 0) 
-      m_hdf5helper->init_write_vel(nstep, m_ZFPmode, m_ZFPpar, m_bufferInterval);
-      /* m_hdf5helper->init_write_vel_compression(nstep, m_ZFPmode, m_ZFPpar, m_bufferInterval); */
+    if (m_compressionMode > 0) 
+      m_hdf5helper->init_write_vel(nstep, m_compressionMode, m_compressionPar, m_bufferInterval);
+      /* m_hdf5helper->init_write_vel_compression(nstep, m_compressionMode, m_compressionPar, m_bufferInterval); */
     else
       /* m_hdf5helper->init_write_vel(nstep); */
       m_hdf5helper->init_write_vel(nstep, 0, 0.0, m_bufferInterval);
   }
   else{
-    if (m_ZFPmode > 0) 
-      m_hdf5helper->init_write_vel(m_ntimestep, m_ZFPmode, m_ZFPpar, m_bufferInterval);
-      /* m_hdf5helper->init_write_vel_compression(m_ntimestep, m_ZFPmode, m_ZFPpar, m_bufferInterval); */
+    if (m_compressionMode > 0) 
+      m_hdf5helper->init_write_vel(m_ntimestep, m_compressionMode, m_compressionPar, m_bufferInterval);
+      /* m_hdf5helper->init_write_vel_compression(m_ntimestep, m_compressioncompressionM, m_compressionPar, m_bufferInterval); */
     else
       /* m_hdf5helper->init_write_vel(m_ntimestep); */
       m_hdf5helper->init_write_vel(m_ntimestep, 0, 0.0, m_bufferInterval);

--- a/src/ESSI3D.C
+++ b/src/ESSI3D.C
@@ -497,25 +497,20 @@ void ESSI3D::write_image_hdf5( int cycle, std::string &path, float_sw4 t,
   // Top grid only
   int g = mEW->mNumberOfGrids-1;
   int doWrite = 0;
-
   int myRank;
+
   MPI_Comm_rank(MPI_COMM_WORLD, &myRank);
 
   for (int i = 0; i < 3; i++) {
     compute_image(a_U[g], i, cycle);
     if (cycle > 0 && (m_nbufstep == m_bufferInterval-1 || cycle == m_ntimestep)) {
-      if (m_ZFPmode > 0) {
-        if (m_precision == 4) 
-          m_hdf5helper->write_vel_compression((void*)m_floatField[i], i, cycle, m_nbufstep+1);
-        else if (m_precision == 8) 
-          m_hdf5helper->write_vel_compression((void*)m_doubleField[i], i, cycle, m_nbufstep+1);
-      }
-      else {
-        if (m_precision == 4) 
-          m_hdf5helper->write_vel((void*)m_floatField[i], i, cycle, m_nbufstep+1);
-        else if (m_precision == 8) 
-          m_hdf5helper->write_vel((void*)m_doubleField[i], i, cycle, m_nbufstep+1);
-      }
+      if (m_precision == 4) 
+        m_hdf5helper->write_vel((void*)m_floatField[i], i, cycle, m_nbufstep+1);
+        /* m_hdf5helper->write_vel_compression((void*)m_floatField[i], i, cycle, m_nbufstep+1); */
+      else if (m_precision == 8) 
+        m_hdf5helper->write_vel((void*)m_doubleField[i], i, cycle, m_nbufstep+1);
+        /* m_hdf5helper->write_vel_compression((void*)m_doubleField[i], i, cycle, m_nbufstep+1); */
+
       doWrite++;
     }
   }
@@ -527,8 +522,8 @@ void ESSI3D::write_image_hdf5( int cycle, std::string &path, float_sw4 t,
     fprintf(stderr, "Error with essioutput write_image_hdf5, not all variables are written correctly!\n");
 
   if (doWrite == 3) {
+    printf("Rank %d: write_image_hdf5 cycle=%d/%d, m_nbufstep=%d\n", myRank, cycle, m_ntimestep, m_nbufstep);
     m_nbufstep = 0;
-    printf("Rank %d: write_image_hdf5 cycle=%d, m_nbufstep=%d\n", myRank, cycle, m_nbufstep);
   }
 }
 #endif // ifdef USE_HDF5

--- a/src/ESSI3D.C
+++ b/src/ESSI3D.C
@@ -506,15 +506,15 @@ void ESSI3D::write_image_hdf5( int cycle, std::string &path, float_sw4 t,
     if (cycle > 0 && (m_nbufstep == m_bufferInterval-1 || cycle == m_ntimestep)) {
       if (m_ZFPmode > 0) {
         if (m_precision == 4) 
-          m_hdf5helper->write_vel_compression((void*)m_floatField[i], i, cycle, m_nbufstep);
+          m_hdf5helper->write_vel_compression((void*)m_floatField[i], i, cycle, m_nbufstep+1);
         else if (m_precision == 8) 
-          m_hdf5helper->write_vel_compression((void*)m_doubleField[i], i, cycle, m_nbufstep);
+          m_hdf5helper->write_vel_compression((void*)m_doubleField[i], i, cycle, m_nbufstep+1);
       }
       else {
         if (m_precision == 4) 
-          m_hdf5helper->write_vel((void*)m_floatField[i], i, cycle, m_nbufstep);
+          m_hdf5helper->write_vel((void*)m_floatField[i], i, cycle, m_nbufstep+1);
         else if (m_precision == 8) 
-          m_hdf5helper->write_vel((void*)m_doubleField[i], i, cycle, m_nbufstep);
+          m_hdf5helper->write_vel((void*)m_doubleField[i], i, cycle, m_nbufstep+1);
       }
       doWrite++;
     }

--- a/src/ESSI3D.h
+++ b/src/ESSI3D.h
@@ -47,6 +47,7 @@
 #define SW4_ZFP_MODE_REVERSIBLE 4
 #define SW4_SZIP                5
 #define SW4_ZLIB                6
+#define SW4_SZ                  7
 
 class EW;
 class ESSI3DHDF5;

--- a/src/ESSI3D.h
+++ b/src/ESSI3D.h
@@ -57,6 +57,7 @@ public:
    ESSI3D( EW * a_ew,
       const std::string& filePrefix,
       int dumpInterval,
+      int bufferInterval,
       float_sw4 coordBox[4],
       float_sw4 depth,
       int precision,
@@ -66,6 +67,7 @@ public:
    ~ESSI3D();
 
    void set_dump_interval( int a_dumpInterval );
+   void set_buffer_interval( int a_bufferInterval );
    void setup( );
 
    double getHDF5Timings();
@@ -80,7 +82,7 @@ public:
        std::string& a_path, Sarray& a_Z );
 
 protected:
-   void compute_image( Sarray& a_U, int a_comp );
+   void compute_image( Sarray& a_U, int a_comp, int cycle );
 
    void write_image( int cycle, std::string& path, float_sw4 t, Sarray& a_Z );
 
@@ -128,6 +130,8 @@ private:
 
    int m_cycle;
    int m_dumpInterval; // Note: this cycle interval to start a new file
+   int m_bufferInterval; // Note: number of steps to buffer data before writting out
+   int m_nbufstep;
    int mWindow[6]; // Local in processor start + end indices for (i,j,k) for last curvilinear grid
    int mGlobalDims[6]; // Global start + end indices for (i,j,k) for last curvilinear grid
    double* m_doubleField;

--- a/src/ESSI3D.h
+++ b/src/ESSI3D.h
@@ -45,6 +45,8 @@
 #define SW4_ZFP_MODE_PRECISION  2
 #define SW4_ZFP_MODE_ACCURACY   3
 #define SW4_ZFP_MODE_REVERSIBLE 4
+#define SW4_SZIP                5
+#define SW4_ZLIB                6
 
 class EW;
 class ESSI3DHDF5;
@@ -61,8 +63,8 @@ public:
       float_sw4 coordBox[4],
       float_sw4 depth,
       int precision,
-      int ZFPmode,
-      double ZFPpar
+      int compressionMode,
+      double compressionPar
       );
    ~ESSI3D();
 
@@ -114,8 +116,8 @@ protected:
 
    bool m_fileOpen;
 
-   int m_ZFPmode;
-   double m_ZFPpar;
+   int m_compressionMode;
+   double m_compressionPar;
 
    static int mPreceedZeros; // number of digits for unique time step in file names
    static int mNumberOfTimeSteps; // number of time steps for the whole sim

--- a/src/ESSI3D.h
+++ b/src/ESSI3D.h
@@ -134,8 +134,8 @@ private:
    int m_nbufstep;
    int mWindow[6]; // Local in processor start + end indices for (i,j,k) for last curvilinear grid
    int mGlobalDims[6]; // Global start + end indices for (i,j,k) for last curvilinear grid
-   double* m_doubleField;
-   float* m_floatField;
+   double** m_doubleField;
+   float** m_floatField;
    bool m_ihavearray;
    int m_ntimestep;
 };

--- a/src/ESSI3D.h
+++ b/src/ESSI3D.h
@@ -41,6 +41,11 @@
 #include "Sarray.h"
 #include "Parallel_IO.h"
 
+#define SW4_ZFP_MODE_RATE       1
+#define SW4_ZFP_MODE_PRECISION  2
+#define SW4_ZFP_MODE_ACCURACY   3
+#define SW4_ZFP_MODE_REVERSIBLE 4
+
 class EW;
 class ESSI3DHDF5;
 
@@ -50,11 +55,14 @@ public:
    static ESSI3D* nil;
 
    ESSI3D( EW * a_ew,
-     const std::string& filePrefix,
+      const std::string& filePrefix,
       int dumpInterval,
       float_sw4 coordBox[4],
       float_sw4 depth,
-      int precision);
+      int precision,
+      int ZFPmode,
+      double ZFPpar
+      );
    ~ESSI3D();
 
    void set_dump_interval( int a_dumpInterval );
@@ -104,6 +112,9 @@ protected:
 
    bool m_fileOpen;
 
+   int m_ZFPmode;
+   double m_ZFPpar;
+
    static int mPreceedZeros; // number of digits for unique time step in file names
    static int mNumberOfTimeSteps; // number of time steps for the whole sim
 
@@ -120,6 +131,7 @@ private:
    int mWindow[6]; // Local in processor start + end indices for (i,j,k) for last curvilinear grid
    int mGlobalDims[6]; // Global start + end indices for (i,j,k) for last curvilinear grid
    double* m_doubleField;
+   float* m_floatField;
    bool m_ihavearray;
    int m_ntimestep;
 };

--- a/src/ESSI3DHDF5.C
+++ b/src/ESSI3DHDF5.C
@@ -248,13 +248,7 @@ void ESSI3DHDF5::write_topo(void* window_array)
         (int) m_global_dims[0], (int) m_global_dims[1], (int) m_global_dims[2]);
     cout << msg;
   }
-  /*
-  if (m_ihavearray)
-    sprintf(msg, "Rank %d creating z dataspace size = %d %d %d\n", myRank,
-        (int) m_global_dims[0], (int) m_global_dims[1], (int) m_global_dims[2]);
-  else
-    sprintf(msg, "Rank %d exiting z write\n", myRank);
-  */
+
   hsize_t z_dims = 3;
   // Modify dataset creation properties to enable chunking
   hid_t prop_id = H5Pcreate (H5P_DATASET_CREATE);
@@ -322,22 +316,14 @@ void ESSI3DHDF5::write_topo(void* window_array)
 
   ierr = H5Sclose(dataspace_id);
   ierr = H5Dclose(dataset_id);
-  /*
-  MPI_Barrier(comm);
-  if (debug && (myRank == 0))
-     cout << "In write_topo_real: done writing data" << endl;
-  */
 
-  /*
-  MPI_Barrier(comm);
-  */
   if (debug && (myRank == 0))
      cout << "Done writing hdf5 z coordinate: " << m_filename << endl;
 #endif
 }
 
 #ifdef WRITE_SEP_DSET
-
+// Not used 
 void ESSI3DHDF5::init_write_vel(int ntimestep, int compressionMode, double compressionPar, int bufferInterval)
 {
   bool debug=false;
@@ -407,9 +393,6 @@ void ESSI3DHDF5::init_write_vel(int ntimestep, int compressionMode, double compr
       continue;
 
     my_chunk[0] = bufferInterval;
-    /* my_chunk[1] = my_count[1]; */
-    /* my_chunk[2] = my_count[2]; */
-    /* my_chunk[3] = my_count[3]; */
     my_chunk[1] = 4;
     my_chunk[2] = 4;
     my_chunk[3] = 4;
@@ -489,6 +472,7 @@ void ESSI3DHDF5::init_write_vel(int ntimestep, int compressionMode, double compr
 #endif
 }
 
+// Not used 
 void ESSI3DHDF5::write_vel(void* window_array, int comp, int cycle, int nstep)
 {
   bool enable_timing = false;
@@ -525,9 +509,6 @@ void ESSI3DHDF5::write_vel(void* window_array, int comp, int cycle, int nstep)
   count[0] = nstep;
 
   for (int curProc = 0; curProc < nProc; curProc++) {
-    /* start[1] = m_all_start_count[curProc*6]; */
-    /* start[2] = m_all_start_count[curProc*6+1]; */
-    /* start[3] = m_all_start_count[curProc*6+2]; */
     count[1] = m_all_start_count[curProc*6+3];
     count[2] = m_all_start_count[curProc*6+4];
     count[3] = m_all_start_count[curProc*6+5];
@@ -576,8 +557,6 @@ void ESSI3DHDF5::write_vel(void* window_array, int comp, int cycle, int nstep)
       cout << "Error from vel H5Dwrite " << endl;
       MPI_Abort(comm,ierr);
     }
-    /* if (debug ) */
-    /*  cout << "Rank" << myRank << " Done writing vel" << endl; */
  
     H5Dclose(dset);
     H5Sclose(dspace);
@@ -599,7 +578,7 @@ void ESSI3DHDF5::write_vel(void* window_array, int comp, int cycle, int nstep)
 }
 
 #else
-
+// In use
 void ESSI3DHDF5::init_write_vel(int ntimestep, int compressionMode, double compressionPar, int bufferInterval)
 {
   bool debug=false;
@@ -622,9 +601,7 @@ void ESSI3DHDF5::init_write_vel(int ntimestep, int compressionMode, double compr
   H5Pset_alloc_time(prop_id, H5D_ALLOC_TIME_LATE);
 
   hsize_t my_chunk[4]={0,0,0,0};
-  /* else { */
-  /*   cout << "Error with ZFP mode, no compression is used!" << endl; */
-  /* } */
+
   if (compressionMode > 0) {
     MPI_Allreduce(&m_window_dims[1], &my_chunk[1], 3, MPI_UNSIGNED_LONG_LONG, MPI_MAX, MPI_COMM_WORLD);
 
@@ -694,11 +671,10 @@ void ESSI3DHDF5::init_write_vel(int ntimestep, int compressionMode, double compr
     }
   }
   H5Pclose(prop_id);
-  /* if (debug ) */
-  /*   cout << "Rank" << myRank << " done creating vel" << endl; */
 #endif
 }
 
+// In use
 void ESSI3DHDF5::write_vel(void* window_array, int comp, int cycle, int nstep)
 {
   bool enable_timing = false;
@@ -776,9 +752,6 @@ void ESSI3DHDF5::write_vel(void* window_array, int comp, int cycle, int nstep)
     cout << "Error from vel H5Dwrite " << endl;
     MPI_Abort(comm,ierr);
   }
-  /* if (debug ) */
-  /*    cout << "Rank" << myRank << " Done writing vel_" << comp << endl; */
-  // H5Sclose(slice_id);
   
   if (enable_timing) {
     write_time = MPI_Wtime() - write_time_start;

--- a/src/ESSI3DHDF5.C
+++ b/src/ESSI3DHDF5.C
@@ -130,6 +130,7 @@ void ESSI3DHDF5::create_file()
   MPI_Info info = MPI_INFO_NULL;
   hid_t prop_id = H5Pcreate(H5P_FILE_ACCESS);
   H5Pset_fapl_mpio(prop_id, comm, info);
+  H5Pset_coll_metadata_write(prop_id, 1);
   m_file_id = H5Fcreate( const_cast<char*>(m_filename.c_str()),
       H5F_ACC_TRUNC, H5P_DEFAULT, prop_id);
   if (m_file_id < 0)
@@ -602,7 +603,7 @@ void ESSI3DHDF5::write_vel(void* window_array, int comp, int cycle, int nstep)
 void ESSI3DHDF5::init_write_vel(int ntimestep, int compressionMode, double compressionPar, int bufferInterval)
 {
   bool debug=false;
-  debug=true;
+  /* debug=true; */
 
 #ifdef USE_HDF5
   int myRank, nProc;
@@ -702,7 +703,7 @@ void ESSI3DHDF5::write_vel(void* window_array, int comp, int cycle, int nstep)
 {
   bool enable_timing = false;
   bool debug=false;
-  debug=true;
+  /* debug=true; */
 #ifdef USE_HDF5
 
   herr_t ierr;
@@ -775,13 +776,13 @@ void ESSI3DHDF5::write_vel(void* window_array, int comp, int cycle, int nstep)
     cout << "Error from vel H5Dwrite " << endl;
     MPI_Abort(comm,ierr);
   }
-  if (debug )
-     cout << "Rank" << myRank << " Done writing vel_" << comp << endl;
+  /* if (debug ) */
+  /*    cout << "Rank" << myRank << " Done writing vel_" << comp << endl; */
   // H5Sclose(slice_id);
   
   if (enable_timing) {
     write_time = MPI_Wtime() - write_time_start;
-    if (cycle % 100  == 0) {
+    if (cycle % 100  == 0 && comp == 0) {
       printf("rank=%d, cycle=%d, comp=%d, write size=%fMB, write time=%f\n", 
               myRank, cycle, comp, write_size/1048576.0, write_time);
       fflush(stdout);

--- a/src/ESSI3DHDF5.C
+++ b/src/ESSI3DHDF5.C
@@ -345,15 +345,7 @@ void ESSI3DHDF5::init_write_vel(int ntimestep)
   if (m_precision == 4) 
       dtype = H5T_NATIVE_FLOAT;
 
-  if (debug)
-  {
-    char msg[1000];
-    sprintf(msg, "Rank %d creating vel dataspaces size = %d %d %d\n", myRank,
-        (int) m_global_dims[0], (int) m_global_dims[1], (int) m_global_dims[2]);
-    cout << msg;
-  }
   // Create the extendible velocity data space and chunk
-  hsize_t num_vel=3;
   hsize_t num_dims=4;
   // m_xvel_dataspace_id = H5Screate_simple(num_dims, m_global_dims, dims);
   hid_t prop_id = H5Pcreate (H5P_DATASET_CREATE);
@@ -370,14 +362,14 @@ void ESSI3DHDF5::init_write_vel(int ntimestep)
   else
     printf("Error with m_ntimestep=%d!\n", ntimestep);
 
-  /* if (myRank == 0) { */
-  /*     printf("m_cycle_dims sizes:\n"); */
-  /*     for (int i = 0; i < num_dims; i++) */ 
-  /*         printf("%llu  ", m_cycle_dims[i]); */
-  /* } */
-  /* printf("\n"); */
+  if (debug) {
+    char msg[1000];
+    sprintf(msg, "Rank %d creating vel dataspaces size = %d %d %d %d\n", myRank,
+        (int) m_cycle_dims[0], (int) m_cycle_dims[1], (int) m_cycle_dims[2], (int) m_cycle_dims[3]);
+    cout << msg;
+  }
 
-  for (int c=0; c < num_vel; c++)
+  for (int c=0; c < 3; c++)
   {
     m_vel_dataspace_id[c] =
       H5Screate_simple(num_dims, m_cycle_dims, m_cycle_dims);
@@ -394,111 +386,111 @@ void ESSI3DHDF5::init_write_vel(int ntimestep)
 #endif
 }
 
-void ESSI3DHDF5::write_vel(void* window_array, int comp, int cycle, int nstep)
-{
-#ifdef USE_HDF5
-  /* bool debug=true; */
-  bool enable_timing = false;
-  bool debug=false;
-  MPI_Comm comm = MPI_COMM_WORLD;
-  int myRank;
-  MPI_Comm_rank(MPI_COMM_WORLD, &myRank);
-  herr_t ierr;
-  double write_time_start, write_time;
-  int write_size = m_precision;
-  m_end_cycle = cycle; // save for header for later when we close the file
-  hid_t dxpl = H5Pcreate(H5P_DATASET_XFER);
-  hid_t dtype = H5T_NATIVE_DOUBLE;
-  if (m_precision == 4) 
-    dtype = H5T_NATIVE_FLOAT;
+/* void ESSI3DHDF5::write_vel(void* window_array, int comp, int cycle, int nstep) */
+/* { */
+/* #ifdef USE_HDF5 */
+/*   /1* bool debug=true; *1/ */
+/*   bool enable_timing = false; */
+/*   bool debug=false; */
+/*   MPI_Comm comm = MPI_COMM_WORLD; */
+/*   int myRank; */
+/*   MPI_Comm_rank(MPI_COMM_WORLD, &myRank); */
+/*   herr_t ierr; */
+/*   double write_time_start, write_time; */
+/*   int write_size = m_precision; */
+/*   m_end_cycle = cycle; // save for header for later when we close the file */
+/*   hid_t dxpl = H5Pcreate(H5P_DATASET_XFER); */
+/*   hid_t dtype = H5T_NATIVE_DOUBLE; */
+/*   if (m_precision == 4) */ 
+/*     dtype = H5T_NATIVE_FLOAT; */
 
-  for (int i = 0; i < 4; i++) 
-      write_size *= m_window_dims[i];
+/*   for (int i = 0; i < 4; i++) */ 
+/*       write_size *= m_window_dims[i]; */
   
-  if (write_size == 0) 
-      return;
+/*   if (write_size == 0) */ 
+/*       return; */
   
-  if (enable_timing) 
-    write_time_start = MPI_Wtime();
-  // Loop over slices and write a new time step
+/*   if (enable_timing) */ 
+/*     write_time_start = MPI_Wtime(); */
+/*   // Loop over slices and write a new time step */
 
-  /* m_cycle_dims[0] = cycle - m_start_cycle + 1; */
-  /* ierr = H5Dset_extent(m_vel_dataset_id[comp], m_cycle_dims); */
-  /* if (ierr < -1) */
-  /* { */
-  /*   cout << "Error from H5Dset_extent " << endl; */
-  /*   MPI_Abort(comm,ierr); */
-  /* } */
-  hsize_t vel_dims=4;
-  hsize_t buf_window_dims[4];
-  buf_window_dims[0] = nstep;
-  buf_window_dims[1] = m_window_dims[1];
-  buf_window_dims[2] = m_window_dims[2];
-  buf_window_dims[3] = m_window_dims[3];
-  /* hid_t window_id = H5Screate_simple(vel_dims, m_window_dims, NULL); */
-  hid_t window_id = H5Screate_simple(vel_dims, buf_window_dims, NULL);
-  // MPI_Barrier(comm);
-  char msg[1000];
-  /*
-  if (debug)
-     cout << "Rank " << myRank <<
-       " in write_vel: starting slab loop" << endl;
-  sprintf(msg, "Rank %d writing vel hyperslab = (%d:%d %d:%d %d:%d %d)\n",
-      myRank, m_window[0], m_window[1], m_window[2], m_window[3],
-      m_window[4], m_window[5], );
-  cout << msg;
-  */
+/*   /1* m_cycle_dims[0] = cycle - m_start_cycle + 1; *1/ */
+/*   /1* ierr = H5Dset_extent(m_vel_dataset_id[comp], m_cycle_dims); *1/ */
+/*   /1* if (ierr < -1) *1/ */
+/*   /1* { *1/ */
+/*   /1*   cout << "Error from H5Dset_extent " << endl; *1/ */
+/*   /1*   MPI_Abort(comm,ierr); *1/ */
+/*   /1* } *1/ */
+/*   hsize_t vel_dims=4; */
+/*   hsize_t buf_window_dims[4]; */
+/*   buf_window_dims[0] = nstep; */
+/*   buf_window_dims[1] = m_window_dims[1]; */
+/*   buf_window_dims[2] = m_window_dims[2]; */
+/*   buf_window_dims[3] = m_window_dims[3]; */
+/*   /1* hid_t window_id = H5Screate_simple(vel_dims, m_window_dims, NULL); *1/ */
+/*   hid_t window_id = H5Screate_simple(vel_dims, buf_window_dims, NULL); */
+/*   // MPI_Barrier(comm); */
+/*   char msg[1000]; */
+/*   /* */
+/*   if (debug) */
+/*      cout << "Rank " << myRank << */
+/*        " in write_vel: starting slab loop" << endl; */
+/*   sprintf(msg, "Rank %d writing vel hyperslab = (%d:%d %d:%d %d:%d %d)\n", */
+/*       myRank, m_window[0], m_window[1], m_window[2], m_window[3], */
+/*       m_window[4], m_window[5], ); */
+/*   cout << msg; */
+/*   *1/ */
 
-  m_vel_dataspace_id[comp] = H5Dget_space(m_vel_dataset_id[comp]);
-  hsize_t start[4]={0,0,0,0}; 
-  start[0] = cycle - m_start_cycle;
-  start[1] = m_window[0]; // local index lo relative to global
-  start[2] = m_window[2]; // local index lo relative to global
-  start[3] = m_window[4]; // local index lo relative to global
-  if (debug)
-  {
-    sprintf(msg, "Rank %d writing vel dataset index = %d %d %d %d\n",
-        myRank,
-        (int) start[0], (int) start[1], (int) start[2], (int) start[3]);
-    cout << msg;
-  }
-  ierr = H5Sselect_hyperslab(m_vel_dataspace_id[comp], H5S_SELECT_SET,
-            start, NULL, buf_window_dims, NULL);
-  if (ierr < 0)
-  {
-    cout << "Error from vel H5Sselect_hyperslab" << endl;
-    MPI_Abort(comm,ierr);
-  }
-  if (debug)
-  {
-    char msg[1000];
-    sprintf(msg, "Writing vel array Rank %d\n", myRank);
-    cout << msg;
-    cout.flush();
-  }
-  ierr = H5Dwrite(m_vel_dataset_id[comp], dtype, window_id,
-      m_vel_dataspace_id[comp], dxpl, window_array);
-  if (ierr < 0)
-  {
-    cout << "Error from vel H5Dwrite " << endl;
-    MPI_Abort(comm,ierr);
-  }
-  if (debug )
-     cout << "Rank" << myRank << "Done writing vel" << endl;
-  // H5Sclose(slice_id);
+/*   m_vel_dataspace_id[comp] = H5Dget_space(m_vel_dataset_id[comp]); */
+/*   hsize_t start[4]={0,0,0,0}; */ 
+/*   start[0] = cycle - m_start_cycle; */
+/*   start[1] = m_window[0]; // local index lo relative to global */
+/*   start[2] = m_window[2]; // local index lo relative to global */
+/*   start[3] = m_window[4]; // local index lo relative to global */
+/*   if (debug) */
+/*   { */
+/*     sprintf(msg, "Rank %d writing vel dataset index = %d %d %d %d\n", */
+/*         myRank, */
+/*         (int) start[0], (int) start[1], (int) start[2], (int) start[3]); */
+/*     cout << msg; */
+/*   } */
+/*   ierr = H5Sselect_hyperslab(m_vel_dataspace_id[comp], H5S_SELECT_SET, */
+/*             start, NULL, buf_window_dims, NULL); */
+/*   if (ierr < 0) */
+/*   { */
+/*     cout << "Error from vel H5Sselect_hyperslab" << endl; */
+/*     MPI_Abort(comm,ierr); */
+/*   } */
+/*   if (debug) */
+/*   { */
+/*     char msg[1000]; */
+/*     sprintf(msg, "Writing vel array Rank %d\n", myRank); */
+/*     cout << msg; */
+/*     cout.flush(); */
+/*   } */
+/*   ierr = H5Dwrite(m_vel_dataset_id[comp], dtype, window_id, */
+/*       m_vel_dataspace_id[comp], dxpl, window_array); */
+/*   if (ierr < 0) */
+/*   { */
+/*     cout << "Error from vel H5Dwrite " << endl; */
+/*     MPI_Abort(comm,ierr); */
+/*   } */
+/*   if (debug ) */
+/*      cout << "Rank" << myRank << "Done writing vel" << endl; */
+/*   // H5Sclose(slice_id); */
   
-  if (enable_timing) {
-    write_time = MPI_Wtime() - write_time_start;
-    if (cycle % 100  == 0) {
-      printf("rank=%d, cycle=%d, comp=%d, write size=%fMB, write time=%f\n", 
-              myRank, cycle, comp, write_size/1048576.0, write_time);
-      fflush(stdout);
-    }
-  }
+/*   if (enable_timing) { */
+/*     write_time = MPI_Wtime() - write_time_start; */
+/*     if (cycle % 100  == 0) { */
+/*       printf("rank=%d, cycle=%d, comp=%d, write size=%fMB, write time=%f\n", */ 
+/*               myRank, cycle, comp, write_size/1048576.0, write_time); */
+/*       fflush(stdout); */
+/*     } */
+/*   } */
 
-  H5Pclose(dxpl);
-#endif
-}
+/*   H5Pclose(dxpl); */
+/* #endif */
+/* } */
 
 /* void ESSI3DHDF5::init_write_vel_compression(int ntimestep, int ZFPmode, double ZFPpar) */
 /* { */
@@ -512,7 +504,6 @@ void ESSI3DHDF5::write_vel(void* window_array, int comp, int cycle, int nstep)
 /*   if (m_precision == 4) */ 
 /*     dtype = H5T_NATIVE_FLOAT; */
 
-/*   hsize_t num_vel=3; */
 /*   hsize_t num_dims=4; */
 /*   hsize_t start_count[6], my_count[4], my_start[4], v_start[4], my_chunk[4], my_size; */
 /*   hid_t prop_id, vspace, vdset, vdcpl[3]; */
@@ -584,7 +575,7 @@ void ESSI3DHDF5::write_vel(void* window_array, int comp, int cycle, int nstep)
 /*     my_chunk[2] = my_count[2]; */
 /*     my_chunk[3] = my_count[3]; */
 
-/*     for (int c = 0; c < num_vel; c++) { */
+/*     for (int c = 0; c < 3; c++) { */
 
 /*       sprintf(dname, "vel_%d_%llu_%llu_%llu", c, v_start[1], v_start[2], v_start[3]); */
 /*       my_dspace = H5Screate_simple(num_dims, my_count, my_count); */
@@ -628,7 +619,7 @@ void ESSI3DHDF5::write_vel(void* window_array, int comp, int cycle, int nstep)
 /*   } */
 
 
-/*   for (int c = 0; c < num_vel; c++) { */
+/*   for (int c = 0; c < 3; c++) { */
 /*     sprintf(dname, "vel_%d ijk layout", c); */
 /*     vdset = H5Dcreate(m_file_id, dname, dtype, vspace, H5P_DEFAULT, vdcpl[c], H5P_DEFAULT); */
 
@@ -795,7 +786,6 @@ void ESSI3DHDF5::init_write_vel_compression(int ntimestep, int ZFPmode, double Z
   debug=true;
 
 #ifdef USE_HDF5
-  MPI_Comm comm = MPI_COMM_WORLD;
   int myRank, nProc;
 
   MPI_Comm_rank(MPI_COMM_WORLD, &myRank);
@@ -805,28 +795,21 @@ void ESSI3DHDF5::init_write_vel_compression(int ntimestep, int ZFPmode, double Z
   if (m_precision == 4) 
       dtype = H5T_NATIVE_FLOAT;
 
-  if (debug && myRank == 0) {
-    char msg[1000];
-    sprintf(msg, "Rank %d creating vel dataspaces size = %d %d %d\n", myRank,
-        (int) m_global_dims[0], (int) m_global_dims[1], (int) m_global_dims[2]);
-    cout << msg;
-  }
-
-  hsize_t my_chunk[4]={0,0,0,0};
-
-  MPI_Allreduce(&m_window_dims[1], &my_chunk[1], 3, MPI_UNSIGNED_LONG_LONG, MPI_MAX, comm);
-
-  my_chunk[0] = bufferInterval;
-  for (int i = 1; i < 4; i++) {
-    if (my_chunk[i] > 4) 
-      my_chunk[i] = ((hsize_t)(my_chunk[i]/4))*4;
-  }
-
   // Create the extendible velocity data space and chunk
-  hsize_t num_vel=3;
   hsize_t num_dims=4;
   // m_xvel_dataspace_id = H5Screate_simple(num_dims, m_global_dims, dims);
   hid_t prop_id = H5Pcreate (H5P_DATASET_CREATE);
+
+#ifdef USE_ZFP
+  hsize_t my_chunk[4]={0,0,0,0};
+  MPI_Allreduce(&m_window_dims[1], &my_chunk[1], 3, MPI_UNSIGNED_LONG_LONG, MPI_MAX, MPI_COMM_WORLD);
+
+  my_chunk[0] = bufferInterval;
+  for (int i = 1; i < 4; i++) {
+    if (my_chunk[i] > 8) 
+      my_chunk[i] = ((hsize_t)(my_chunk[i]/8))*4;
+  }
+
   herr_t ierr = H5Pset_chunk (prop_id, num_dims, my_chunk);
   if (debug && myRank == 0) {
     printf("nts=%d\nChunk sizes:\n", ntimestep);
@@ -836,22 +819,21 @@ void ESSI3DHDF5::init_write_vel_compression(int ntimestep, int ZFPmode, double Z
     fflush(stdout);
   }
 
-#ifdef USE_ZFP
-      if (ZFPmode == SW4_ZFP_MODE_RATE) {
-        H5Pset_zfp_rate(prop_id, ZFPpar);
-      }
-      else if (ZFPmode == SW4_ZFP_MODE_PRECISION) {
-        H5Pset_zfp_precision(prop_id, ZFPpar);
-      }
-      else if (ZFPmode == SW4_ZFP_MODE_ACCURACY) {
-        H5Pset_zfp_accuracy(prop_id, ZFPpar);
-      }
-      else if (ZFPmode == SW4_ZFP_MODE_REVERSIBLE) {
-        H5Pset_zfp_reversible(prop_id);
-      }
-      else {
-        cout << "Error with ZFP mode, no compression is used!" << endl;
-      }
+  if (ZFPmode == SW4_ZFP_MODE_RATE) {
+    H5Pset_zfp_rate(prop_id, ZFPpar);
+  }
+  else if (ZFPmode == SW4_ZFP_MODE_PRECISION) {
+    H5Pset_zfp_precision(prop_id, ZFPpar);
+  }
+  else if (ZFPmode == SW4_ZFP_MODE_ACCURACY) {
+    H5Pset_zfp_accuracy(prop_id, ZFPpar);
+  }
+  else if (ZFPmode == SW4_ZFP_MODE_REVERSIBLE) {
+    H5Pset_zfp_reversible(prop_id);
+  }
+  else {
+    cout << "Error with ZFP mode, no compression is used!" << endl;
+  }
 #endif
 
   if (ntimestep > 0) 
@@ -859,19 +841,22 @@ void ESSI3DHDF5::init_write_vel_compression(int ntimestep, int ZFPmode, double Z
   else
     printf("Error with m_ntimestep=%d!\n", ntimestep);
 
-  for (int c=0; c < num_vel; c++)
-  {
-    m_vel_dataspace_id[c] =
-      H5Screate_simple(num_dims, m_cycle_dims, m_cycle_dims);
-      /* H5Screate_simple(num_dims, m_cycle_dims, m_global_dims); */
-    // Modify dataset creation properties to enable chunking
+  if (debug && myRank == 0) {
+    char msg[1000];
+    sprintf(msg, "Rank %d creating vel dataspaces size = %d %d %d %d\n", myRank,
+        (int) m_cycle_dims[0], (int) m_cycle_dims[1], (int) m_cycle_dims[2], (int) m_cycle_dims[3]);
+    cout << msg;
+    fflush(stdout);
+  }
+
+  for (int c=0; c<3; c++) {
+    m_vel_dataspace_id[c] = H5Screate_simple(num_dims, m_cycle_dims, m_cycle_dims);
     char var[100];
     sprintf(var, "vel_%d ijk layout", c);
-    m_vel_dataset_id[c] = H5Dcreate2 (m_file_id, var, dtype,
-        m_vel_dataspace_id[c], H5P_DEFAULT, prop_id, H5P_DEFAULT);
+    m_vel_dataset_id[c] = H5Dcreate2 (m_file_id, var, dtype, m_vel_dataspace_id[c], H5P_DEFAULT, prop_id, H5P_DEFAULT);
     if (m_vel_dataset_id[c] < 0) {
       printf("Error with H5Dcreate!\n");
-      MPI_Abort(comm,ierr);
+      MPI_Abort(MPI_COMM_WORLD, -1);
     }
   }
   H5Pclose(prop_id);
@@ -880,7 +865,7 @@ void ESSI3DHDF5::init_write_vel_compression(int ntimestep, int ZFPmode, double Z
 #endif
 }
 
-void ESSI3DHDF5::write_vel_compression(void* window_array, int comp, int cycle, int nstep)
+void ESSI3DHDF5::write_vel(void* window_array, int comp, int cycle, int nstep)
 {
   bool enable_timing = false;
   bool debug=false;
@@ -911,11 +896,7 @@ void ESSI3DHDF5::write_vel_compression(void* window_array, int comp, int cycle, 
 
   /* m_cycle_dims[0] = cycle - m_start_cycle + 1; */
 
-  if (cycle - m_start_cycle + nstep > m_cycle_dims[0]) 
-    nstep = m_cycle_dims[0] - cycle + m_start_cycle;
-
   hsize_t vel_dims=4;
-
   hsize_t buf_window_dims[4];
   buf_window_dims[0] = nstep;
   buf_window_dims[1] = m_window_dims[1];
@@ -926,7 +907,7 @@ void ESSI3DHDF5::write_vel_compression(void* window_array, int comp, int cycle, 
 
   m_vel_dataspace_id[comp] = H5Dget_space(m_vel_dataset_id[comp]);
   hsize_t start[4]={0,0,0,0};
-  start[0] = cycle - m_start_cycle;
+  start[0] = cycle - m_start_cycle - nstep + 1;
   start[1] = m_window[0]; // local index lo relative to global
   start[2] = m_window[2]; // local index lo relative to global
   start[3] = m_window[4]; // local index lo relative to global
@@ -946,8 +927,7 @@ void ESSI3DHDF5::write_vel_compression(void* window_array, int comp, int cycle, 
     H5Sselect_none(window_id);
   }
   else {
-    ierr = H5Sselect_hyperslab(m_vel_dataspace_id[comp], H5S_SELECT_SET,
-              start, NULL, buf_window_dims, NULL);
+    ierr = H5Sselect_hyperslab(m_vel_dataspace_id[comp], H5S_SELECT_SET, start, NULL, buf_window_dims, NULL);
     if (ierr < 0) {
       cout << "Error from vel H5Sselect_hyperslab" << endl;
       MPI_Abort(comm,ierr);
@@ -955,8 +935,7 @@ void ESSI3DHDF5::write_vel_compression(void* window_array, int comp, int cycle, 
   }
 
   ierr = H5Dwrite(m_vel_dataset_id[comp], dtype, window_id, m_vel_dataspace_id[comp], dxpl, window_array);
-  if (ierr < 0)
-  {
+  if (ierr < 0) {
     cout << "Error from vel H5Dwrite " << endl;
     MPI_Abort(comm,ierr);
   }

--- a/src/ESSI3DHDF5.C
+++ b/src/ESSI3DHDF5.C
@@ -43,6 +43,8 @@
 #include "H5Zzfp_props.h"
 #endif
 
+/* #define WRITE_SEP_DSET 1 */
+
 using std::cout;
 
 ESSI3DHDF5* ESSI3DHDF5::nil=static_cast<ESSI3DHDF5*>(0);
@@ -333,457 +335,267 @@ void ESSI3DHDF5::write_topo(void* window_array)
 #endif
 }
 
-void ESSI3DHDF5::init_write_vel(int ntimestep)
+#ifdef WRITE_SEP_DSET
+
+void ESSI3DHDF5::init_write_vel(int ntimestep, int ZFPmode, double ZFPpar, int bufferInterval)
 {
-#ifdef USE_HDF5
-  /* bool debug=true; */
   bool debug=false;
+  /* debug=true; */
+#ifdef USE_HDF5
   MPI_Comm comm = MPI_COMM_WORLD;
-  int myRank;
-  MPI_Comm_rank(MPI_COMM_WORLD, &myRank);
+  int myRank, nProc;
+  hid_t my_dspace, my_dset;
   hid_t dtype = H5T_NATIVE_DOUBLE;
   if (m_precision == 4) 
-      dtype = H5T_NATIVE_FLOAT;
+    dtype = H5T_NATIVE_FLOAT;
 
-  // Create the extendible velocity data space and chunk
   hsize_t num_dims=4;
-  // m_xvel_dataspace_id = H5Screate_simple(num_dims, m_global_dims, dims);
-  hid_t prop_id = H5Pcreate (H5P_DATASET_CREATE);
-  // Tang
-  /* herr_t ierr = H5Pset_chunk (prop_id, num_dims, m_slice_dims); */
-  /* if (myRank == 0) { */
-  /*     printf("Chunk sizes:\n"); */
-  /*     for (int i = 0; i < num_dims; i++) */ 
-  /*         printf("%llu  ", m_slice_dims[i]); */
-  /* } */
-  /* printf("\n"); */
+  hsize_t start_count[6], my_count[4], my_start[4], v_start[4], my_chunk[4], my_size;
+  hid_t prop_id, vspace, vdset, vdcpl[3];
+
+  MPI_Comm_rank(MPI_COMM_WORLD, &myRank);
+  MPI_Comm_size(MPI_COMM_WORLD, &nProc);
+
+  // local index lo relative to global
+  start_count[0] = m_window[0]; 
+  start_count[1] = m_window[2];
+  start_count[2] = m_window[4];
+
+  // local size
+  start_count[3] = m_window_dims[1];
+  start_count[4] = m_window_dims[2];
+  start_count[5] = m_window_dims[3];
+
+  m_all_start_count = (hsize_t*)malloc(sizeof(hsize_t)*nProc*6);
+  if (m_all_start_count == NULL) {
+    printf("ESSI3DHDF5::init_write_vel_compression error with malloc, abort!\n");
+    MPI_Abort(comm, -1);
+  }
+
+  MPI_Allgather(start_count, 6, MPI_UNSIGNED_LONG_LONG, m_all_start_count, 6, MPI_UNSIGNED_LONG_LONG, comm);
+
   if (ntimestep > 0) 
     m_cycle_dims[0]  = ntimestep + 1;
-  else
+  else {
     printf("Error with m_ntimestep=%d!\n", ntimestep);
-
-  if (debug) {
-    char msg[1000];
-    sprintf(msg, "Rank %d creating vel dataspaces size = %d %d %d %d\n", myRank,
-        (int) m_cycle_dims[0], (int) m_cycle_dims[1], (int) m_cycle_dims[2], (int) m_cycle_dims[3]);
-    cout << msg;
+    MPI_Abort(comm, -1);
   }
 
-  for (int c=0; c < 3; c++)
-  {
-    m_vel_dataspace_id[c] =
-      H5Screate_simple(num_dims, m_cycle_dims, m_cycle_dims);
-      /* H5Screate_simple(num_dims, m_cycle_dims, m_global_dims); */
-    // Modify dataset creation properties to enable chunking
-    char var[100];
-    sprintf(var, "vel_%d ijk layout", c);
-    m_vel_dataset_id[c] = H5Dcreate2 (m_file_id, var, dtype,
-        m_vel_dataspace_id[c], H5P_DEFAULT, prop_id, H5P_DEFAULT);
+  // create virtual dataset
+  vdcpl[0] = H5Pcreate (H5P_DATASET_CREATE);
+  vdcpl[1] = H5Pcreate (H5P_DATASET_CREATE);
+  vdcpl[2] = H5Pcreate (H5P_DATASET_CREATE);
+
+  // Every rank needs to participate dataset create process
+  char dname[1024];
+  my_start[0] = my_start[1] = my_start[2] = my_start[3] = 0;
+
+  for (int i = 0; i < nProc; i++) {
+    v_start[0] = 0;
+    v_start[1] = m_all_start_count[i*6];
+    v_start[2] = m_all_start_count[i*6+1];
+    v_start[3] = m_all_start_count[i*6+2];
+
+    my_count[0] = ntimestep + 1;
+    my_count[1] = m_all_start_count[i*6+3];
+    my_count[2] = m_all_start_count[i*6+4];
+    my_count[3] = m_all_start_count[i*6+5];
+
+    my_size = my_count[1] * my_count[2] * my_count[3];
+    if (my_size == 0)
+      continue;
+
+    my_chunk[0] = bufferInterval;
+    /* my_chunk[1] = my_count[1]; */
+    /* my_chunk[2] = my_count[2]; */
+    /* my_chunk[3] = my_count[3]; */
+    my_chunk[1] = 4;
+    my_chunk[2] = 4;
+    my_chunk[3] = 4;
+
+    if (debug && myRank==0) {
+      printf("proc=%d\nChunk sizes:\n", myRank);
+      for (int i = 0; i < num_dims; i++) 
+        printf("%llu  ", my_chunk[i]);
+      printf("\n");
+      fflush(stdout);
+    }
+
+    prop_id = H5Pcreate (H5P_DATASET_CREATE);
+
+#ifdef USE_ZFP
+    // Single chunk per rank per timestep for now
+    H5Pset_chunk(prop_id, num_dims, my_chunk);
+
+    if (ZFPmode == SW4_ZFP_MODE_RATE) {
+      H5Pset_zfp_rate(prop_id, ZFPpar);
+    }
+    else if (ZFPmode == SW4_ZFP_MODE_PRECISION) {
+      H5Pset_zfp_precision(prop_id, (unsigned int)ZFPpar);
+    }
+    else if (ZFPmode == SW4_ZFP_MODE_ACCURACY) {
+      H5Pset_zfp_accuracy(prop_id, ZFPpar);
+    }
+    else if (ZFPmode == SW4_ZFP_MODE_REVERSIBLE) {
+      H5Pset_zfp_reversible(prop_id);
+    }
+#endif
+
+    for (int c = 0; c < 3; c++) {
+
+      sprintf(dname, "vel_%d_%llu_%llu_%llu", c, v_start[1], v_start[2], v_start[3]);
+      my_dspace = H5Screate_simple(num_dims, my_count, my_count);
+
+      if (debug && myRank==0) 
+        printf("Creating dset [%s] \n", dname);
+
+      my_dset = H5Dcreate(m_file_id, dname, dtype, my_dspace, H5P_DEFAULT, prop_id, H5P_DEFAULT);
+
+      // Global virtual dset
+      vspace = H5Screate_simple(num_dims, m_cycle_dims, m_cycle_dims);
+      H5Sselect_hyperslab(vspace, H5S_SELECT_SET, v_start, NULL, my_count, NULL);
+      H5Pset_virtual(vdcpl[c], vspace, const_cast<char*>(m_filename.c_str()), dname, my_dspace);
+
+      H5Sclose(my_dspace);
+      H5Dclose(my_dset);
+    }
+
+    H5Pclose(prop_id);
   }
-  H5Pclose(prop_id);
+
+
+  for (int c = 0; c < 3; c++) {
+    sprintf(dname, "vel_%d ijk layout", c);
+    vdset = H5Dcreate(m_file_id, dname, dtype, vspace, H5P_DEFAULT, vdcpl[c], H5P_DEFAULT);
+
+    H5Dclose(vdset);
+  }
+
   if (debug )
-     cout << "Rank" << myRank << "Done creating vel" << endl;
+     cout << "Rank" << myRank << " done creating vel" << endl;
+
+  H5Pclose(vdcpl[0]);
+  H5Pclose(vdcpl[1]);
+  H5Pclose(vdcpl[2]);
+
 #endif
 }
 
-/* void ESSI3DHDF5::write_vel(void* window_array, int comp, int cycle, int nstep) */
-/* { */
-/* #ifdef USE_HDF5 */
-/*   /1* bool debug=true; *1/ */
-/*   bool enable_timing = false; */
-/*   bool debug=false; */
-/*   MPI_Comm comm = MPI_COMM_WORLD; */
-/*   int myRank; */
-/*   MPI_Comm_rank(MPI_COMM_WORLD, &myRank); */
-/*   herr_t ierr; */
-/*   double write_time_start, write_time; */
-/*   int write_size = m_precision; */
-/*   m_end_cycle = cycle; // save for header for later when we close the file */
-/*   hid_t dxpl = H5Pcreate(H5P_DATASET_XFER); */
-/*   hid_t dtype = H5T_NATIVE_DOUBLE; */
-/*   if (m_precision == 4) */ 
-/*     dtype = H5T_NATIVE_FLOAT; */
-
-/*   for (int i = 0; i < 4; i++) */ 
-/*       write_size *= m_window_dims[i]; */
-  
-/*   if (write_size == 0) */ 
-/*       return; */
-  
-/*   if (enable_timing) */ 
-/*     write_time_start = MPI_Wtime(); */
-/*   // Loop over slices and write a new time step */
-
-/*   /1* m_cycle_dims[0] = cycle - m_start_cycle + 1; *1/ */
-/*   /1* ierr = H5Dset_extent(m_vel_dataset_id[comp], m_cycle_dims); *1/ */
-/*   /1* if (ierr < -1) *1/ */
-/*   /1* { *1/ */
-/*   /1*   cout << "Error from H5Dset_extent " << endl; *1/ */
-/*   /1*   MPI_Abort(comm,ierr); *1/ */
-/*   /1* } *1/ */
-/*   hsize_t vel_dims=4; */
-/*   hsize_t buf_window_dims[4]; */
-/*   buf_window_dims[0] = nstep; */
-/*   buf_window_dims[1] = m_window_dims[1]; */
-/*   buf_window_dims[2] = m_window_dims[2]; */
-/*   buf_window_dims[3] = m_window_dims[3]; */
-/*   /1* hid_t window_id = H5Screate_simple(vel_dims, m_window_dims, NULL); *1/ */
-/*   hid_t window_id = H5Screate_simple(vel_dims, buf_window_dims, NULL); */
-/*   // MPI_Barrier(comm); */
-/*   char msg[1000]; */
-/*   /* */
-/*   if (debug) */
-/*      cout << "Rank " << myRank << */
-/*        " in write_vel: starting slab loop" << endl; */
-/*   sprintf(msg, "Rank %d writing vel hyperslab = (%d:%d %d:%d %d:%d %d)\n", */
-/*       myRank, m_window[0], m_window[1], m_window[2], m_window[3], */
-/*       m_window[4], m_window[5], ); */
-/*   cout << msg; */
-/*   *1/ */
-
-/*   m_vel_dataspace_id[comp] = H5Dget_space(m_vel_dataset_id[comp]); */
-/*   hsize_t start[4]={0,0,0,0}; */ 
-/*   start[0] = cycle - m_start_cycle; */
-/*   start[1] = m_window[0]; // local index lo relative to global */
-/*   start[2] = m_window[2]; // local index lo relative to global */
-/*   start[3] = m_window[4]; // local index lo relative to global */
-/*   if (debug) */
-/*   { */
-/*     sprintf(msg, "Rank %d writing vel dataset index = %d %d %d %d\n", */
-/*         myRank, */
-/*         (int) start[0], (int) start[1], (int) start[2], (int) start[3]); */
-/*     cout << msg; */
-/*   } */
-/*   ierr = H5Sselect_hyperslab(m_vel_dataspace_id[comp], H5S_SELECT_SET, */
-/*             start, NULL, buf_window_dims, NULL); */
-/*   if (ierr < 0) */
-/*   { */
-/*     cout << "Error from vel H5Sselect_hyperslab" << endl; */
-/*     MPI_Abort(comm,ierr); */
-/*   } */
-/*   if (debug) */
-/*   { */
-/*     char msg[1000]; */
-/*     sprintf(msg, "Writing vel array Rank %d\n", myRank); */
-/*     cout << msg; */
-/*     cout.flush(); */
-/*   } */
-/*   ierr = H5Dwrite(m_vel_dataset_id[comp], dtype, window_id, */
-/*       m_vel_dataspace_id[comp], dxpl, window_array); */
-/*   if (ierr < 0) */
-/*   { */
-/*     cout << "Error from vel H5Dwrite " << endl; */
-/*     MPI_Abort(comm,ierr); */
-/*   } */
-/*   if (debug ) */
-/*      cout << "Rank" << myRank << "Done writing vel" << endl; */
-/*   // H5Sclose(slice_id); */
-  
-/*   if (enable_timing) { */
-/*     write_time = MPI_Wtime() - write_time_start; */
-/*     if (cycle % 100  == 0) { */
-/*       printf("rank=%d, cycle=%d, comp=%d, write size=%fMB, write time=%f\n", */ 
-/*               myRank, cycle, comp, write_size/1048576.0, write_time); */
-/*       fflush(stdout); */
-/*     } */
-/*   } */
-
-/*   H5Pclose(dxpl); */
-/* #endif */
-/* } */
-
-/* void ESSI3DHDF5::init_write_vel_compression(int ntimestep, int ZFPmode, double ZFPpar) */
-/* { */
-/* #ifdef USE_HDF5 */
-/*   /1* bool debug=true; *1/ */
-/*   bool debug=false; */
-/*   MPI_Comm comm = MPI_COMM_WORLD; */
-/*   int myRank, nProc; */
-/*   hid_t my_dspace, my_dset; */
-/*   hid_t dtype = H5T_NATIVE_DOUBLE; */
-/*   if (m_precision == 4) */ 
-/*     dtype = H5T_NATIVE_FLOAT; */
-
-/*   hsize_t num_dims=4; */
-/*   hsize_t start_count[6], my_count[4], my_start[4], v_start[4], my_chunk[4], my_size; */
-/*   hid_t prop_id, vspace, vdset, vdcpl[3]; */
-
-/*   MPI_Comm_rank(MPI_COMM_WORLD, &myRank); */
-/*   MPI_Comm_size(MPI_COMM_WORLD, &nProc); */
-
-/*   if (debug) */
-/*   { */
-/*     char msg[1000]; */
-/*     sprintf(msg, "Rank %d creating vel dataspaces size = %d %d %d\n", myRank, */
-/*         (int) m_global_dims[0], (int) m_global_dims[1], (int) m_global_dims[2]); */
-/*     cout << msg; */
-/*   } */
-
-/*   // local index lo relative to global */
-/*   start_count[0] = m_window[0]; */ 
-/*   start_count[1] = m_window[2]; */
-/*   start_count[2] = m_window[4]; */
-
-/*   // local size */
-/*   start_count[3] = m_window_dims[1]; */
-/*   start_count[4] = m_window_dims[2]; */
-/*   start_count[5] = m_window_dims[3]; */
-
-/*   m_all_start_count = (hsize_t*)malloc(sizeof(hsize_t)*nProc*6); */
-/*   if (m_all_start_count == NULL) { */
-/*     printf("ESSI3DHDF5::init_write_vel_compression error with malloc, abort!\n"); */
-/*     MPI_Abort(comm, -1); */
-/*   } */
-
-/*   MPI_Allgather(start_count, 6, MPI_UNSIGNED_LONG_LONG, m_all_start_count, 6, MPI_UNSIGNED_LONG_LONG, comm); */
-
-/*   if (ntimestep > 0) */ 
-/*     m_cycle_dims[0]  = ntimestep + 1; */
-/*   else { */
-/*     printf("Error with m_ntimestep=%d!\n", ntimestep); */
-/*     MPI_Abort(comm, -1); */
-/*   } */
-
-/*   // create virtual dataset */
-/*   prop_id = H5Pcreate (H5P_DATASET_CREATE); */
-
-/*   vdcpl[0] = H5Pcreate (H5P_DATASET_CREATE); */
-/*   vdcpl[1] = H5Pcreate (H5P_DATASET_CREATE); */
-/*   vdcpl[2] = H5Pcreate (H5P_DATASET_CREATE); */
-
-/*   // Every rank needs to participate dataset create process */
-/*   char dname[1024]; */
-/*   my_start[0] = my_start[1] = my_start[2] = my_start[3] = 0; */
-
-/*   for (int i = 0; i < nProc; i++) { */
-/*     v_start[0] = 0; */
-/*     v_start[1] = m_all_start_count[i*6]; */
-/*     v_start[2] = m_all_start_count[i*6+1]; */
-/*     v_start[3] = m_all_start_count[i*6+2]; */
-
-/*     my_count[0] = ntimestep + 1; */
-/*     my_count[1] = m_all_start_count[i*6+3]; */
-/*     my_count[2] = m_all_start_count[i*6+4]; */
-/*     my_count[3] = m_all_start_count[i*6+5]; */
-
-/*     my_size = my_count[1] * my_count[2] * my_count[3]; */
-/*     if (my_size == 0) */
-/*       continue; */
-
-/*     my_chunk[0] = 1; */
-/*     my_chunk[1] = my_count[1]; */
-/*     my_chunk[2] = my_count[2]; */
-/*     my_chunk[3] = my_count[3]; */
-
-/*     for (int c = 0; c < 3; c++) { */
-
-/*       sprintf(dname, "vel_%d_%llu_%llu_%llu", c, v_start[1], v_start[2], v_start[3]); */
-/*       my_dspace = H5Screate_simple(num_dims, my_count, my_count); */
-
-/*       // Single chunk per rank per timestep for now */
-/*       H5Pset_chunk (prop_id, num_dims, my_chunk); */
-/* #ifdef USE_ZFP */
-/*       if (ZFPmode == SW4_ZFP_MODE_RATE) { */
-/*         H5Pset_zfp_rate(prop_id, ZFPpar); */
-/*       } */
-/*       else if (ZFPmode == SW4_ZFP_MODE_PRECISION) { */
-/*         H5Pset_zfp_precision(prop_id, ZFPpar); */
-/*       } */
-/*       else if (ZFPmode == SW4_ZFP_MODE_ACCURACY) { */
-/*         H5Pset_zfp_accuracy(prop_id, ZFPpar); */
-/*       } */
-/*       else if (ZFPmode == SW4_ZFP_MODE_REVERSIBLE) { */
-/*         H5Pset_zfp_reversible(prop_id); */
-/*       } */
-/*       else { */
-/*         cout << "Error with ZFP mode, no compression is used!" << endl; */
-/*       } */
-/* #endif */
-
-/*       my_dset = H5Dcreate(m_file_id, dname, dtype, my_dspace, H5P_DEFAULT, prop_id, H5P_DEFAULT); */
-
-/*       // Global virtual dset */
-/*       vspace = H5Screate_simple(num_dims, m_cycle_dims, m_cycle_dims); */
-/*       H5Sselect_hyperslab(vspace, H5S_SELECT_SET, v_start, NULL, my_count, NULL); */
-/*       H5Pset_virtual(vdcpl[c], vspace, const_cast<char*>(m_filename.c_str()), dname, my_dspace); */
-
-/*       /1* if (i != myRank) { *1/ */
-/*         H5Sclose(my_dspace); */
-/*         H5Dclose(my_dset); */
-/*       /1* } *1/ */
-/*       /1* else { *1/ */
-/*       /1*   m_vel_dataspace_id[c] = my_dspace; *1/ */
-/*       /1*   m_vel_dataset_id[c]   = my_dset; *1/ */
-/*       /1* } *1/ */
-/*     } */
-/*   } */
-
-
-/*   for (int c = 0; c < 3; c++) { */
-/*     sprintf(dname, "vel_%d ijk layout", c); */
-/*     vdset = H5Dcreate(m_file_id, dname, dtype, vspace, H5P_DEFAULT, vdcpl[c], H5P_DEFAULT); */
-
-/*     H5Dclose(vdset); */
-/*   } */
-
-/*   if (debug ) */
-/*      cout << "Rank" << myRank << "Done creating vel" << endl; */
-
-
-/*   H5Pclose(prop_id); */
-/*   H5Pclose(vdcpl[0]); */
-/*   H5Pclose(vdcpl[1]); */
-/*   H5Pclose(vdcpl[2]); */
-
-/* #endif */
-/* } */
-
-/* void ESSI3DHDF5::write_vel_compression(void* window_array, int comp, int cycle) */
-/* { */
-/* #ifdef USE_HDF5 */
-/*   /1* bool debug=true; *1/ */
-/*   bool debug=false; */
-/*   bool enable_timing = false; */
-/*   MPI_Comm comm = MPI_COMM_WORLD; */
-/*   int myRank, nProc; */
-/*   herr_t ierr; */
-/*   hid_t window_id, dxpl, dset, dspace, fspace; */
-/*   double write_time_start, write_time; */
-/*   int write_size = m_precision; */
-/*   hsize_t vel_dims=4, start[4]={0,0,0,0}, count[4]={0,0,0,0}; */
-/*   char dname[1024]; */
-/*   hid_t dtype = H5T_NATIVE_DOUBLE; */
-/*   if (m_precision == 4) */ 
-/*     dtype = H5T_NATIVE_FLOAT; */
-
-/*   m_end_cycle = cycle; // save for header for later when we close the file */
-
-/*   ASSERT(m_all_start_count != NULL); */
-
-/*   dxpl = H5Pcreate(H5P_DATASET_XFER); */
-/*   H5Pset_dxpl_mpio(dxpl, H5FD_MPIO_COLLECTIVE); */
-
-/*   MPI_Comm_rank(MPI_COMM_WORLD, &myRank); */
-/*   MPI_Comm_size(MPI_COMM_WORLD, &nProc); */
-
-/*   if (enable_timing) */ 
-/*     write_time_start = MPI_Wtime(); */
-
-/*   start[0] = cycle - m_start_cycle; */
-/*   count[0] = 1; */
-
-/*   for (int curProc = 0; curProc < nProc; curProc++) { */
-/*     /1* start[1] = m_all_start_count[curProc*6]; *1/ */
-/*     /1* start[2] = m_all_start_count[curProc*6+1]; *1/ */
-/*     /1* start[3] = m_all_start_count[curProc*6+2]; *1/ */
-/*     count[1] = m_all_start_count[curProc*6+3]; */
-/*     count[2] = m_all_start_count[curProc*6+4]; */
-/*     count[3] = m_all_start_count[curProc*6+5]; */
-
-/*     write_size = m_precision; */
-/*     for (int i = 0; i < 4; i++) */ 
-/*       write_size *= count[i]; */
-    
-/*     if (write_size == 0) */ 
-/*       continue; */
-
-/*     sprintf(dname, "vel_%d_%llu_%llu_%llu", comp, m_all_start_count[curProc*6], */ 
-/*             m_all_start_count[curProc*6+1], m_all_start_count[curProc*6+2]); */
-
-/*     dset = H5Dopen(m_file_id, dname, H5P_DEFAULT); */
-/*     if (dset < 0) { */
-/*       cout << "Error from vel dset open!" << endl; */
-/*       MPI_Abort(comm, -1); */
-/*     } */
-
-/*     // Everyone needs to participate the dataset write when filter is enabled */
-/*     dspace = H5Screate_simple(vel_dims, count, count); */
-/*     fspace = H5Dget_space(dset); */
-/*     if (fspace == 0) { */
-/*         cout << "Error with fspace" << endl; */
-/*         MPI_Abort(comm,ierr); */
-/*     } */
-
-/*     if (curProc == myRank) { */
-
-/*       // debug */
-/*       /1* fprintf(stderr, "Rank %d, [%s],  start: %llu, %llu, %llu, %llu, count: %llu, %llu, %llu, %llu \n", *1/ */ 
-/*       /1*         myRank, dname, start[0], start[1], start[2], start[3], count[0], count[1], count[2], count[3]); *1/ */
-
-/*       ierr = H5Sselect_hyperslab(fspace, H5S_SELECT_SET, start, NULL, count, NULL); */
-/*       if (ierr < 0) { */
-/*         cout << "Error from vel H5Sselect_hyperslab" << endl; */
-/*         MPI_Abort(comm,ierr); */
-/*       } */
-/*     } */
-/*     else { */
-/*       H5Sselect_none(fspace); */
-/*       H5Sselect_none(dspace); */
-/*     } */
-
-/*     ierr = H5Dwrite(dset, dtype, dspace, fspace, dxpl, window_array); */
-/*     if (ierr < 0) { */
-/*       cout << "Error from vel H5Dwrite " << endl; */
-/*       MPI_Abort(comm,ierr); */
-/*     } */
-/*     if (debug ) */
-/*      cout << "Rank" << myRank << "Done writing vel" << endl; */
- 
-/*     H5Dclose(dset); */
-/*     H5Sclose(dspace); */
-/*     H5Sclose(fspace); */
-/*   } */
-
-  
-/*   if (enable_timing) { */
-/*     write_time = MPI_Wtime() - write_time_start; */
-/*     if (cycle % 100  == 0) { */
-/*       printf("rank=%d, cycle=%d, comp=%d, write size=%fMB, write time=%f\n", */ 
-/*               myRank, cycle, comp, write_size/1048576.0, write_time); */
-/*       fflush(stdout); */
-/*     } */
-/*   } */
-
-/*   H5Pclose(dxpl); */
-/* #endif */
-/* } */
-
-void ESSI3DHDF5::close_file()
+void ESSI3DHDF5::write_vel(void* window_array, int comp, int cycle, int nstep)
 {
+  bool enable_timing = false;
+  bool debug=false;
+  /* debug=true; */
+
 #ifdef USE_HDF5
-  // Updated header with final start,end cycle
-  hsize_t dim=2;
-  hid_t dataspace_id = H5Screate_simple(1,&dim,NULL);
-  hid_t dataset_id = H5Dcreate2 (m_file_id, "cycle start, end", H5T_STD_I32LE,
-      dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-  int cycles[2] = {m_start_cycle, m_end_cycle};
-  herr_t ierr = H5Dwrite(dataset_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL,
-      m_mpiprop_id, cycles);
-  ierr = H5Dclose(dataset_id);
-  ierr = H5Sclose(dataspace_id);
+  MPI_Comm comm = MPI_COMM_WORLD;
+  int myRank, nProc;
+  herr_t ierr;
+  hid_t window_id, dxpl, dset, dspace, fspace;
+  double write_time_start, write_time;
+  int write_size = m_precision;
+  hsize_t vel_dims=4, start[4]={0,0,0,0}, count[4]={0,0,0,0};
+  char dname[1024];
+  hid_t dtype = H5T_NATIVE_DOUBLE;
+  if (m_precision == 4) 
+    dtype = H5T_NATIVE_FLOAT;
 
-  // Close each velocity dataspace, then dataset
-  for (int comp=0; comp < 3; comp++)
-  {
-    if (m_vel_dataspace_id[comp] > 0) 
-      H5Sclose(m_vel_dataspace_id[comp]);
-    if (m_vel_dataset_id[comp] > 0) 
-      H5Dclose(m_vel_dataset_id[comp]);
-  }
-  H5Pclose(m_mpiprop_id);
-  H5Fclose(m_file_id);
+  m_end_cycle = cycle; // save for header for later when we close the file
 
-  if (m_all_start_count) {
-    free(m_all_start_count);
-    m_all_start_count = NULL;
+  ASSERT(m_all_start_count != NULL);
+
+  dxpl = H5Pcreate(H5P_DATASET_XFER);
+  H5Pset_dxpl_mpio(dxpl, H5FD_MPIO_COLLECTIVE);
+
+  MPI_Comm_rank(MPI_COMM_WORLD, &myRank);
+  MPI_Comm_size(MPI_COMM_WORLD, &nProc);
+
+  if (enable_timing) 
+    write_time_start = MPI_Wtime();
+
+  start[0] = cycle - m_start_cycle - nstep + 1;
+  count[0] = nstep;
+
+  for (int curProc = 0; curProc < nProc; curProc++) {
+    /* start[1] = m_all_start_count[curProc*6]; */
+    /* start[2] = m_all_start_count[curProc*6+1]; */
+    /* start[3] = m_all_start_count[curProc*6+2]; */
+    count[1] = m_all_start_count[curProc*6+3];
+    count[2] = m_all_start_count[curProc*6+4];
+    count[3] = m_all_start_count[curProc*6+5];
+
+    write_size = m_precision;
+    for (int i = 0; i < 4; i++) 
+      write_size *= count[i];
+
+    sprintf(dname, "vel_%d_%llu_%llu_%llu", comp, m_all_start_count[curProc*6], 
+            m_all_start_count[curProc*6+1], m_all_start_count[curProc*6+2]);
+
+    dset = H5Dopen(m_file_id, dname, H5P_DEFAULT);
+    if (dset < 0) {
+      cout << "Error from vel dset open!" << endl;
+      MPI_Abort(comm, -1);
+    }
+
+    // Everyone needs to participate the dataset write when filter is enabled
+    dspace = H5Screate_simple(vel_dims, count, count);
+    fspace = H5Dget_space(dset);
+    if (fspace == 0) {
+        cout << "Error with fspace" << endl;
+        MPI_Abort(comm,ierr);
+    }
+
+    if (curProc == myRank) {
+
+      if (debug) {
+        fprintf(stderr, "Rank %d, [%s],  start: %llu, %llu, %llu, %llu, count: %llu, %llu, %llu, %llu \n", 
+                myRank, dname, start[0], start[1], start[2], start[3], count[0], count[1], count[2], count[3]);
+      }
+
+      ierr = H5Sselect_hyperslab(fspace, H5S_SELECT_SET, start, NULL, count, NULL);
+      if (ierr < 0) {
+        cout << "Error from vel H5Sselect_hyperslab" << endl;
+        MPI_Abort(comm,ierr);
+      }
+    }
+    else {
+      H5Sselect_none(fspace);
+      H5Sselect_none(dspace);
+    }
+
+    ierr = H5Dwrite(dset, dtype, dspace, fspace, dxpl, window_array);
+    if (ierr < 0) {
+      cout << "Error from vel H5Dwrite " << endl;
+      MPI_Abort(comm,ierr);
+    }
+    /* if (debug ) */
+    /*  cout << "Rank" << myRank << " Done writing vel" << endl; */
+ 
+    H5Dclose(dset);
+    H5Sclose(dspace);
+    H5Sclose(fspace);
   }
+
+  
+  if (enable_timing) {
+    write_time = MPI_Wtime() - write_time_start;
+    if (cycle % 100  == 0) {
+      printf("rank=%d, cycle=%d, comp=%d, write size=%fMB, write time=%f\n", 
+              myRank, cycle, comp, write_size/1048576.0, write_time);
+      fflush(stdout);
+    }
+  }
+
+  H5Pclose(dxpl);
 #endif
 }
 
-void ESSI3DHDF5::init_write_vel_compression(int ntimestep, int ZFPmode, double ZFPpar, int bufferInterval)
+#else
+
+void ESSI3DHDF5::init_write_vel(int ntimestep, int ZFPmode, double ZFPpar, int bufferInterval)
 {
   bool debug=false;
-  debug=true;
+  /* debug=true; */
 
 #ifdef USE_HDF5
   int myRank, nProc;
@@ -799,40 +611,48 @@ void ESSI3DHDF5::init_write_vel_compression(int ntimestep, int ZFPmode, double Z
   hsize_t num_dims=4;
   // m_xvel_dataspace_id = H5Screate_simple(num_dims, m_global_dims, dims);
   hid_t prop_id = H5Pcreate (H5P_DATASET_CREATE);
+  H5Pset_alloc_time(prop_id, H5D_ALLOC_TIME_LATE);
 
 #ifdef USE_ZFP
   hsize_t my_chunk[4]={0,0,0,0};
-  MPI_Allreduce(&m_window_dims[1], &my_chunk[1], 3, MPI_UNSIGNED_LONG_LONG, MPI_MAX, MPI_COMM_WORLD);
+  /* else { */
+  /*   cout << "Error with ZFP mode, no compression is used!" << endl; */
+  /* } */
+  if (ZFPmode > 0) {
+    MPI_Allreduce(&m_window_dims[1], &my_chunk[1], 3, MPI_UNSIGNED_LONG_LONG, MPI_MAX, MPI_COMM_WORLD);
 
-  my_chunk[0] = bufferInterval;
-  for (int i = 1; i < 4; i++) {
-    if (my_chunk[i] > 8) 
-      my_chunk[i] = ((hsize_t)(my_chunk[i]/8))*4;
-  }
+    // Keep last dimension (z)
+    for (int i = 1; i < 3; i++) {
+      if (my_chunk[i] > 4) 
+        my_chunk[i] = ((hsize_t)(my_chunk[i]/4))*4;
+    }
+    my_chunk[0] = bufferInterval;
+    /* my_chunk[1] = 32; */
+    /* my_chunk[2] = 32; */
+    /* my_chunk[3] = 16; */
 
-  herr_t ierr = H5Pset_chunk (prop_id, num_dims, my_chunk);
-  if (debug && myRank == 0) {
-    printf("nts=%d\nChunk sizes:\n", ntimestep);
-    for (int i = 0; i < num_dims; i++) 
-      printf("%llu  ", my_chunk[i]);
-    printf("\n");
-    fflush(stdout);
-  }
+    H5Pset_chunk (prop_id, num_dims, my_chunk);
 
-  if (ZFPmode == SW4_ZFP_MODE_RATE) {
-    H5Pset_zfp_rate(prop_id, ZFPpar);
-  }
-  else if (ZFPmode == SW4_ZFP_MODE_PRECISION) {
-    H5Pset_zfp_precision(prop_id, ZFPpar);
-  }
-  else if (ZFPmode == SW4_ZFP_MODE_ACCURACY) {
-    H5Pset_zfp_accuracy(prop_id, ZFPpar);
-  }
-  else if (ZFPmode == SW4_ZFP_MODE_REVERSIBLE) {
-    H5Pset_zfp_reversible(prop_id);
-  }
-  else {
-    cout << "Error with ZFP mode, no compression is used!" << endl;
+    if (myRank == 0) {
+      printf("nts=%d\nChunk sizes:\n", ntimestep);
+      for (int i = 0; i < num_dims; i++) 
+        printf("%llu  ", my_chunk[i]);
+      printf("\n");
+      fflush(stdout);
+    }
+
+    if (ZFPmode == SW4_ZFP_MODE_RATE) {
+      H5Pset_zfp_rate(prop_id, ZFPpar);
+    }
+    else if (ZFPmode == SW4_ZFP_MODE_PRECISION) {
+      H5Pset_zfp_precision(prop_id, (unsigned int)ZFPpar);
+    }
+    else if (ZFPmode == SW4_ZFP_MODE_ACCURACY) {
+      H5Pset_zfp_accuracy(prop_id, ZFPpar);
+    }
+    else if (ZFPmode == SW4_ZFP_MODE_REVERSIBLE) {
+      H5Pset_zfp_reversible(prop_id);
+    }
   }
 #endif
 
@@ -869,7 +689,7 @@ void ESSI3DHDF5::write_vel(void* window_array, int comp, int cycle, int nstep)
 {
   bool enable_timing = false;
   bool debug=false;
-  debug=true;
+  /* debug=true; */
 #ifdef USE_HDF5
 
   herr_t ierr;
@@ -940,7 +760,7 @@ void ESSI3DHDF5::write_vel(void* window_array, int comp, int cycle, int nstep)
     MPI_Abort(comm,ierr);
   }
   if (debug )
-     cout << "Rank" << myRank << "Done writing vel" << endl;
+     cout << "Rank" << myRank << " Done writing vel_" << comp << endl;
   // H5Sclose(slice_id);
   
   if (enable_timing) {
@@ -953,5 +773,39 @@ void ESSI3DHDF5::write_vel(void* window_array, int comp, int cycle, int nstep)
   }
 
   H5Pclose(dxpl);
+#endif
+}
+
+#endif
+
+void ESSI3DHDF5::close_file()
+{
+#ifdef USE_HDF5
+  // Updated header with final start,end cycle
+  hsize_t dim=2;
+  hid_t dataspace_id = H5Screate_simple(1,&dim,NULL);
+  hid_t dataset_id = H5Dcreate2 (m_file_id, "cycle start, end", H5T_STD_I32LE,
+      dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  int cycles[2] = {m_start_cycle, m_end_cycle};
+  herr_t ierr = H5Dwrite(dataset_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL,
+      m_mpiprop_id, cycles);
+  ierr = H5Dclose(dataset_id);
+  ierr = H5Sclose(dataspace_id);
+
+  // Close each velocity dataspace, then dataset
+  for (int comp=0; comp < 3; comp++)
+  {
+    if (m_vel_dataspace_id[comp] > 0) 
+      H5Sclose(m_vel_dataspace_id[comp]);
+    if (m_vel_dataset_id[comp] > 0) 
+      H5Dclose(m_vel_dataset_id[comp]);
+  }
+  H5Pclose(m_mpiprop_id);
+  H5Fclose(m_file_id);
+
+  if (m_all_start_count) {
+    free(m_all_start_count);
+    m_all_start_count = NULL;
+  }
 #endif
 }

--- a/src/ESSI3DHDF5.h
+++ b/src/ESSI3DHDF5.h
@@ -59,7 +59,7 @@ public:
   void write_vel(void* window_array, int comp, int cycle, int nstep);
 
   void init_write_vel_compression(int ntimestep, int ZFPmode, double ZFPpar, int dumpInterval);
-  void write_vel_compression(void* window_array, int comp, int cycle, int nstep);
+  /* void write_vel_compression(void* window_array, int comp, int cycle, int nstep); */
 
   const std::string& filename() {return m_filename;};
   void set_ihavearray(bool ihavearray) {m_ihavearray=ihavearray;};

--- a/src/ESSI3DHDF5.h
+++ b/src/ESSI3DHDF5.h
@@ -55,10 +55,11 @@ public:
     double (&origin)[3], int cycle, double t, double dt);
   void write_topo(void* window_array);
 
-  void init_write_vel(int ntimestep);
+  /* void init_write_vel(int ntimestep); */
   void write_vel(void* window_array, int comp, int cycle, int nstep);
 
-  void init_write_vel_compression(int ntimestep, int ZFPmode, double ZFPpar, int dumpInterval);
+  void init_write_vel(int ntimestep, int ZFPmode, double ZFPpar, int dumpInterval);
+  /* void init_write_vel_compression(int ntimestep, int ZFPmode, double ZFPpar, int dumpInterval); */
   /* void write_vel_compression(void* window_array, int comp, int cycle, int nstep); */
 
   const std::string& filename() {return m_filename;};

--- a/src/ESSI3DHDF5.h
+++ b/src/ESSI3DHDF5.h
@@ -56,10 +56,10 @@ public:
   void write_topo(void* window_array);
 
   void init_write_vel(int ntimestep);
-  void write_vel(void* window_array, int comp, int cycle);
+  void write_vel(void* window_array, int comp, int cycle, int nstep);
 
-  void init_write_vel_compression(int ntimestep, int ZFPmode, double ZFPpar);
-  void write_vel_compression(void* window_array, int comp, int cycle);
+  void init_write_vel_compression(int ntimestep, int ZFPmode, double ZFPpar, int dumpInterval);
+  void write_vel_compression(void* window_array, int comp, int cycle, int nstep);
 
   const std::string& filename() {return m_filename;};
   void set_ihavearray(bool ihavearray) {m_ihavearray=ihavearray;};

--- a/src/ESSI3DHDF5.h
+++ b/src/ESSI3DHDF5.h
@@ -53,10 +53,13 @@ public:
   void close_file();
   void write_header(double h, double (&lonlat_origin)[2], double az,
     double (&origin)[3], int cycle, double t, double dt);
-  void write_topo(double* window_array);
+  void write_topo(void* window_array);
 
   void init_write_vel(int ntimestep);
-  void write_vel(double* window_array, int comp, int cycle);
+  void write_vel(void* window_array, int comp, int cycle);
+
+  void init_write_vel_compression(int ntimestep, int ZFPmode, double ZFPpar);
+  void write_vel_compression(void* window_array, int comp, int cycle);
 
   const std::string& filename() {return m_filename;};
   void set_ihavearray(bool ihavearray) {m_ihavearray=ihavearray;};
@@ -88,6 +91,8 @@ private:
   hid_t m_mpiprop_id;
   hid_t m_vel_dataset_id[3];
   hid_t m_vel_dataspace_id[3];
+
+  hsize_t *m_all_start_count;
 #endif // def USE_HDF5
 };
 

--- a/src/ESSI3DHDF5.h
+++ b/src/ESSI3DHDF5.h
@@ -55,12 +55,9 @@ public:
     double (&origin)[3], int cycle, double t, double dt);
   void write_topo(void* window_array);
 
-  /* void init_write_vel(int ntimestep); */
   void write_vel(void* window_array, int comp, int cycle, int nstep);
 
   void init_write_vel(int ntimestep, int ZFPmode, double ZFPpar, int dumpInterval);
-  /* void init_write_vel_compression(int ntimestep, int ZFPmode, double ZFPpar, int dumpInterval); */
-  /* void write_vel_compression(void* window_array, int comp, int cycle, int nstep); */
 
   const std::string& filename() {return m_filename;};
   void set_ihavearray(bool ihavearray) {m_ihavearray=ihavearray;};

--- a/src/TimeSeries.C
+++ b/src/TimeSeries.C
@@ -1188,9 +1188,11 @@ write_hdf5_format(int npts, hid_t grp, float *y, float btime, float dt, char *va
       if (j >= write_npts) 
         break;
       write_data[j++] = y[i];
-       if (i > 0 && y[i-1] != 0 && y[i] == 0) {
-         fprintf(stderr, "SACHDF5 possible zero value error, y[%d]=%e, y[%d]=%e\n", i-1, y[i-1], i, y[i]);
-       }
+#if defined(BZ_DEBUG) || defined(USE_HDF5_ZERO_SAC_CHECK)
+      if (i > 0 && y[i-1] != 0 && y[i] == 0) {
+        fprintf(stderr, "SACHDF5 possible zero value error, y[%d]=%e, y[%d]=%e\n", i-1, y[i-1], i, y[i]);
+      }
+#endif
     }
   }
 

--- a/src/TimeSeries.C
+++ b/src/TimeSeries.C
@@ -1188,6 +1188,9 @@ write_hdf5_format(int npts, hid_t grp, float *y, float btime, float dt, char *va
       if (j >= write_npts) 
         break;
       write_data[j++] = y[i];
+       if (i > 0 && y[i-1] != 0 && y[i] == 0) {
+         fprintf(stderr, "SACHDF5 possible zero value error, y[%d]=%e, y[%d]=%e\n", i-1, y[i-1], i, y[i]);
+       }
     }
   }
 

--- a/src/main.C
+++ b/src/main.C
@@ -45,6 +45,11 @@
 #endif
 #include "version.h"
 
+#ifdef USE_ZFP
+#include "H5Zzfp_lib.h"
+#include "H5Zzfp_props.h"
+#endif
+
 using namespace std;
 
 void usage(string thereason)
@@ -135,6 +140,10 @@ main(int argc, char **argv)
   vector<vector<Source*> > GlobalSources; 
 // Save the time series here
   vector<vector<TimeSeries*> > GlobalTimeSeries;
+
+#ifdef USE_ZFP
+  H5Z_zfp_initialize();
+#endif
 
 // make a new simulation object by reading the input file 'fileName'
   EW simulation(fileName, GlobalSources, GlobalTimeSeries );
@@ -243,6 +252,9 @@ main(int argc, char **argv)
   }
   
 
+#ifdef USE_ZFP
+    H5Z_zfp_finalize();
+#endif
 // Stop MPI
   MPI_Finalize();
   return status;

--- a/src/main.C
+++ b/src/main.C
@@ -50,6 +50,10 @@
 #include "H5Zzfp_props.h"
 #endif
 
+#ifdef USE_SZ
+#include "H5Z_SZ.h"
+#endif
+
 using namespace std;
 
 void usage(string thereason)
@@ -143,6 +147,13 @@ main(int argc, char **argv)
 
 #ifdef USE_ZFP
   H5Z_zfp_initialize();
+#endif
+
+#ifdef USE_SZ
+  char *cfgFile = getenv("SZ_CONFIG_FILE");
+  if (NULL == cfgFile)
+    cfgFile = "sz.config";
+  H5Z_SZ_Init(cfgFile);
 #endif
 
 // make a new simulation object by reading the input file 'fileName'
@@ -253,8 +264,13 @@ main(int argc, char **argv)
   
 
 #ifdef USE_ZFP
-    H5Z_zfp_finalize();
+  H5Z_zfp_finalize();
 #endif
+
+#ifdef USE_SZ
+  H5Z_SZ_Finalize();
+#endif
+
 // Stop MPI
   MPI_Finalize();
   return status;

--- a/src/parseInputFile.C
+++ b/src/parseInputFile.C
@@ -409,6 +409,7 @@ bool EW::parseInputFile( vector<vector<Source*> > & a_GlobalUniqueSources,
 // setup communicators for 3D solutions on all grids
   setupMPICommunications();
 
+
 // Make curvilinear grid and compute metric
   for( int g=mNumberOfCartesianGrids ; g < mNumberOfGrids ; g++ )
      m_gridGenerator->generate_grid_and_met( this, g, mX[g], mY[g], mZ[g], mJ[g], mMetric[g] );
@@ -429,6 +430,7 @@ bool EW::parseInputFile( vector<vector<Source*> > & a_GlobalUniqueSources,
   //        setup_metric();
   //     }
   //  }
+
 // output grid size info
   if (m_myRank == 0)
   {
@@ -455,6 +457,7 @@ bool EW::parseInputFile( vector<vector<Source*> > & a_GlobalUniqueSources,
   while (!inputFile.eof())
   {
      inputFile.getline(buffer, 256);
+
      if (strlen(buffer) > 0) // empty lines produce this
      {
        if (startswith("#", buffer) || 
@@ -558,6 +561,8 @@ bool EW::parseInputFile( vector<vector<Source*> > & a_GlobalUniqueSources,
          processImage(buffer, false);
        else if (startswith("volimage", buffer))
           processImage3D(buffer);
+       else if (startswith("ssioutput", buffer))
+          processESSI3D(buffer);
        else if (startswith("essioutput", buffer))
           processESSI3D(buffer);
        else if (startswith("boundary_conditions", buffer))
@@ -3891,13 +3896,13 @@ void EW::processImage3D( char* buffer )
 void EW::processESSI3D( char* buffer )
 {
    int dumpInterval=-1, bufferInterval=1;
-   string filePrefix="essioutput";
+   string filePrefix="ssioutput";
    float_sw4 coordValue;
    float_sw4 coordBox[4];
    const float_sw4 zero=0.0;
    int precision = 8;
-   int ZFPmode = 0;
-   double ZFPpar;
+   int compressionMode = 0;
+   double compressionPar;
    
    // Default is whole domain
    coordBox[0] = zero;
@@ -3908,10 +3913,10 @@ void EW::processESSI3D( char* buffer )
    float_sw4 depth = -999.99; // default not specified
 
    char* token = strtok(buffer, " \t");
-   CHECK_INPUT(strcmp("essioutput", token) == 0, "ERROR: Not a essioutput line...: " << token );
+   CHECK_INPUT(strcmp("ssioutput", token) == 0 || strcmp("essioutput", token) == 0, "ERROR: Not a essioutput/ssioutput line...: " << token );
 
    token = strtok(NULL, " \t");
-   string err = "essioutput Error: ";
+   string err = "ssioutput Error: ";
    while (token != NULL)
    {
      // while there are tokens in the string still
@@ -3973,52 +3978,70 @@ void EW::processESSI3D( char* buffer )
           token += 10; // skip precision=
           precision = atoi(token);
           if (precision != 4 && precision != 8) 
-              badOption("essioutput precision", token);
+              badOption("ssioutput precision", token);
           if (proc_zero())
-            cout << "\nESSI ouput will use " << precision*8 << "-bit floating point values." << endl;
+            cout << "SSI ouput will use " << precision*8 << "-bit floating point values." << endl;
       }
       else if (startswith("zfp-rate=", token))
       {
           token += 9;
-          ZFPmode = SW4_ZFP_MODE_RATE;
-          ZFPpar = atof(token);
+          compressionMode = SW4_ZFP_MODE_RATE;
+          compressionPar = atof(token);
           if (proc_zero())
-            cout << "\nESSI ouput will use ZFP rate=" << ZFPpar << endl;
+            cout << "SSI ouput will use ZFP rate=" << compressionPar << endl;
       }
       else if (startswith("zfp-precision=", token))
       {
           token += 14;
-          ZFPmode = SW4_ZFP_MODE_PRECISION;
-          ZFPpar = atof(token);
+          compressionMode = SW4_ZFP_MODE_PRECISION;
+          compressionPar = atof(token);
           if (proc_zero())
-            cout << "\nESSI ouput will use ZFP precision=" << ZFPpar << endl;
+            cout << "SSI ouput will use ZFP precision=" << compressionPar << endl;
       }
       else if (startswith("zfp-accuracy=", token))
       {
           token += 13;
-          ZFPmode = SW4_ZFP_MODE_ACCURACY;
-          ZFPpar = atof(token);
+          compressionMode = SW4_ZFP_MODE_ACCURACY;
+          compressionPar = atof(token);
           if (proc_zero())
-            cout << "\nESSI ouput will use ZFP accuracy=" << ZFPpar << endl;
+            cout << "SSI ouput will use ZFP accuracy=" << compressionPar << endl;
       }
       else if (startswith("zfp-reversible=", token))
       {
           token += 15;
-          ZFPmode = SW4_ZFP_MODE_REVERSIBLE;
+          compressionMode = SW4_ZFP_MODE_REVERSIBLE;
           if (proc_zero())
-            cout << "\nESSI ouput will use ZFP reversible mode" << endl;
+            cout << "SSI ouput will use ZFP reversible mode" << endl;
+      }
+      else if (startswith("zlib=", token))
+      {
+          token += 5;
+          compressionMode = SW4_ZLIB;
+          compressionPar = atof(token);
+          if (proc_zero())
+            cout << "SSI ouput will use ZLIB level=" << (int)compressionPar << endl;
+      }
+      else if (startswith("szip=", token))
+      {
+          token += 5;
+          compressionMode = SW4_SZIP;
+          if (proc_zero())
+            cout << "SSI ouput will use SZIP" << endl;
       }
       else
       {
-          badOption("essioutput", token);
+          badOption("ssioutput", token);
       }
       token = strtok(NULL, " \t");
    }
 
 #ifndef USE_ZFP
-   if (ZFPmode != 0 && proc_zero()) 
+   if (compressionMode != 0 && proc_zero()) 
       cout << "WARNING: SW4 is not compiled with ZFP but ZFP command is used " << endl;
 #endif
+
+   if (compressionMode != 0 && bufferInterval == 1) 
+     bufferInterval = 100;
 
    // Check the specified min/max values make sense
    for (int d=0; d < 2*2; d+=2)
@@ -4027,7 +4050,7 @@ void EW::processESSI3D( char* buffer )
       {
          char coordName[2] = {'x','y'};
          if (proc_zero())
-           cout << "ERROR: essioutput subdomain " << coordName[d] <<
+           cout << "ERROR: ssioutput subdomain " << coordName[d] <<
               " coordinate max value " << coordBox[d+1] <<
               " is less than min value " << coordBox[d] << endl;
          MPI_Abort(MPI_COMM_WORLD, 1);
@@ -4037,11 +4060,11 @@ void EW::processESSI3D( char* buffer )
    // Use depth if zmin/zmax values are specified
    if ((depth < 0) && proc_zero())
    {
-      cout << "WARNING: essioutput depth not specified or less than zero, setting to zero" << endl;
+      cout << "WARNING: ssioutput depth not specified or less than zero, setting to zero" << endl;
       depth=0;
    }
 
-   ESSI3D* essi3d = new ESSI3D( this, filePrefix, dumpInterval, bufferInterval, coordBox, depth, precision, ZFPmode, ZFPpar);
+   ESSI3D* essi3d = new ESSI3D( this, filePrefix, dumpInterval, bufferInterval, coordBox, depth, precision, compressionMode, compressionPar);
    addESSI3D( essi3d );
 }
 

--- a/src/parseInputFile.C
+++ b/src/parseInputFile.C
@@ -3893,7 +3893,7 @@ void EW::processImage3D( char* buffer )
 //-----------------------------------------------------------------------
 void EW::processESSI3D( char* buffer )
 {
-   int dumpInterval=-1, bufferInterval=-1;
+   int dumpInterval=-1, bufferInterval=1;
    string filePrefix="essioutput";
    float_sw4 coordValue;
    float_sw4 coordBox[4];

--- a/src/parseInputFile.C
+++ b/src/parseInputFile.C
@@ -4018,6 +4018,11 @@ void EW::processESSI3D( char* buffer )
       token = strtok(NULL, " \t");
    }
 
+#ifndef USE_ZFP
+   if (ZFPmode != 0 && proc_zero()) 
+      cout << "WARNING: SW4 is not compiled with ZFP but ZFP command is used " << endl;
+#endif
+
    // Check the specified min/max values make sense
    for (int d=0; d < 2*2; d+=2)
    {

--- a/src/parseInputFile.C
+++ b/src/parseInputFile.C
@@ -3899,6 +3899,8 @@ void EW::processESSI3D( char* buffer )
    float_sw4 coordBox[4];
    const float_sw4 zero=0.0;
    int precision = 8;
+   int ZFPmode = 0;
+   double ZFPpar;
    
    // Default is whole domain
    coordBox[0] = zero;
@@ -3971,7 +3973,38 @@ void EW::processESSI3D( char* buffer )
           if (precision != 4 && precision != 8) 
               badOption("essioutput precision", token);
           if (proc_zero())
-              cout << "\nESSI ouput will use " << precision*8 << "-bit floating point values." << endl;
+            cout << "\nESSI ouput will use " << precision*8 << "-bit floating point values." << endl;
+      }
+      else if (startswith("zfp-rate=", token))
+      {
+          token += 9;
+          ZFPmode = SW4_ZFP_MODE_RATE;
+          ZFPpar = atof(token);
+          if (proc_zero())
+            cout << "\nESSI ouput will use ZFP rate=" << ZFPpar << endl;
+      }
+      else if (startswith("zfp-precision=", token))
+      {
+          token += 14;
+          ZFPmode = SW4_ZFP_MODE_PRECISION;
+          ZFPpar = atof(token);
+          if (proc_zero())
+            cout << "\nESSI ouput will use ZFP precision=" << ZFPpar << endl;
+      }
+      else if (startswith("zfp-accuracy=", token))
+      {
+          token += 13;
+          ZFPmode = SW4_ZFP_MODE_ACCURACY;
+          ZFPpar = atof(token);
+          if (proc_zero())
+            cout << "\nESSI ouput will use ZFP accuracy=" << ZFPpar << endl;
+      }
+      else if (startswith("zfp-reversible=", token))
+      {
+          token += 15;
+          ZFPmode = SW4_ZFP_MODE_REVERSIBLE;
+          if (proc_zero())
+            cout << "\nESSI ouput will use ZFP reversible mode" << endl;
       }
       else
       {
@@ -4001,7 +4034,7 @@ void EW::processESSI3D( char* buffer )
       depth=0;
    }
 
-   ESSI3D* essi3d = new ESSI3D( this, filePrefix, dumpInterval, coordBox, depth, precision);
+   ESSI3D* essi3d = new ESSI3D( this, filePrefix, dumpInterval, coordBox, depth, precision, ZFPmode, ZFPpar);
    addESSI3D( essi3d );
 }
 

--- a/src/parseInputFile.C
+++ b/src/parseInputFile.C
@@ -3893,7 +3893,7 @@ void EW::processImage3D( char* buffer )
 //-----------------------------------------------------------------------
 void EW::processESSI3D( char* buffer )
 {
-   int dumpInterval=-1;
+   int dumpInterval=-1, bufferInterval=-1;
    string filePrefix="essioutput";
    float_sw4 coordValue;
    float_sw4 coordBox[4];
@@ -3930,6 +3930,11 @@ void EW::processESSI3D( char* buffer )
       {
           token += 13; // skip dumpInterval=
           dumpInterval = atoi(token);
+      }
+      else if (startswith("bufferInterval=", token))
+      {
+          token += 15; // skip bufferInterval=
+          bufferInterval = atoi(token);
       }
       else if (startswith("xmin=", token))
       {
@@ -4034,7 +4039,7 @@ void EW::processESSI3D( char* buffer )
       depth=0;
    }
 
-   ESSI3D* essi3d = new ESSI3D( this, filePrefix, dumpInterval, coordBox, depth, precision, ZFPmode, ZFPpar);
+   ESSI3D* essi3d = new ESSI3D( this, filePrefix, dumpInterval, bufferInterval, coordBox, depth, precision, ZFPmode, ZFPpar);
    addESSI3D( essi3d );
 }
 

--- a/src/parseInputFile.C
+++ b/src/parseInputFile.C
@@ -4028,6 +4028,13 @@ void EW::processESSI3D( char* buffer )
           if (proc_zero())
             cout << "SSI ouput will use SZIP" << endl;
       }
+      else if (startswith("sz=", token))
+      {
+          token += 5;
+          compressionMode = SW4_SZ;
+          if (proc_zero())
+            cout << "SSI ouput will use SZ with configuration file [" << getenv("SZ_CONFIG_FILE") << "]" << endl;
+      }
       else
       {
           badOption("ssioutput", token);
@@ -4038,6 +4045,11 @@ void EW::processESSI3D( char* buffer )
 #ifndef USE_ZFP
    if (compressionMode != 0 && proc_zero()) 
       cout << "WARNING: SW4 is not compiled with ZFP but ZFP command is used " << endl;
+#endif
+
+#ifndef USE_SZ
+   if (compressionMode != 0 && proc_zero()) 
+      cout << "WARNING: SW4 is not compiled with SZ but SZ command is used " << endl;
 #endif
 
    if (compressionMode != 0 && bufferInterval == 1) 

--- a/src/readhdf5.C
+++ b/src/readhdf5.C
@@ -49,7 +49,6 @@
 #include "readhdf5.h"
 
 #ifdef USE_HDF5
-
 #include "hdf5.h"
 
 struct traverse_data_t {
@@ -125,7 +124,11 @@ static herr_t traverse_func (hid_t loc_id, const char *grp_name, const H5L_info_
 {
   hid_t grp, dset, attr;
   herr_t status;
+#if H5_VERSION_GE(1,12,0)
+  H5O_info1_t infobuf;
+#else
   H5O_info_t infobuf;
+#endif
   EW *a_ew;
   double data[3];
   double lon, lat, depth, x, y, z;
@@ -138,7 +141,11 @@ static herr_t traverse_func (hid_t loc_id, const char *grp_name, const H5L_info_
   a_ew = op_data->ew;
   ASSERT(a_ew != NULL);
 
+#if H5_VERSION_GE(1,12,0)
+  status = H5Oget_info_by_name1(loc_id, grp_name, &infobuf, H5P_DEFAULT);
+#else
   status = H5Oget_info_by_name(loc_id, grp_name, &infobuf, H5P_DEFAULT);
+#endif
   if (infobuf.type == H5O_TYPE_GROUP) {
     /* if (op_data->myRank == 0) */
     /*   printf ("Group: [%s] \n", grp_name); */
@@ -345,7 +352,11 @@ static herr_t traverse_func2 (hid_t loc_id, const char *grp_name, const H5L_info
 {
   hid_t grp, dset, attr;
   herr_t status;
+#if H5_VERSION_GE(1,12,0)
+  H5O_info1_t infobuf;
+#else
   H5O_info_t infobuf;
+#endif
   float data[3];
   int isnsew;
 
@@ -353,7 +364,11 @@ static herr_t traverse_func2 (hid_t loc_id, const char *grp_name, const H5L_info
 
   struct traverse_data2_t *op_data = (struct traverse_data2_t *)operator_data;
 
+#if H5_VERSION_GE(1,12,0)
+  status = H5Oget_info_by_name1(loc_id, grp_name, &infobuf, H5P_DEFAULT);
+#else
   status = H5Oget_info_by_name(loc_id, grp_name, &infobuf, H5P_DEFAULT);
+#endif
   if (infobuf.type == H5O_TYPE_GROUP) {
     /* if (op_data->myRank == 0) */
     /*   printf ("Group: [%s] \n", grp_name); */

--- a/src/readhdf5.C
+++ b/src/readhdf5.C
@@ -138,7 +138,7 @@ static herr_t traverse_func (hid_t loc_id, const char *grp_name, const H5L_info_
   a_ew = op_data->ew;
   ASSERT(a_ew != NULL);
 
-  status = H5Oget_info_by_name (loc_id, grp_name, &infobuf, H5P_DEFAULT);
+  status = H5Oget_info_by_name(loc_id, grp_name, &infobuf, H5P_DEFAULT);
   if (infobuf.type == H5O_TYPE_GROUP) {
     /* if (op_data->myRank == 0) */
     /*   printf ("Group: [%s] \n", grp_name); */
@@ -353,7 +353,7 @@ static herr_t traverse_func2 (hid_t loc_id, const char *grp_name, const H5L_info
 
   struct traverse_data2_t *op_data = (struct traverse_data2_t *)operator_data;
 
-  status = H5Oget_info_by_name (loc_id, grp_name, &infobuf, H5P_DEFAULT);
+  status = H5Oget_info_by_name(loc_id, grp_name, &infobuf, H5P_DEFAULT);
   if (infobuf.type == H5O_TYPE_GROUP) {
     /* if (op_data->myRank == 0) */
     /*   printf ("Group: [%s] \n", grp_name); */

--- a/src/sachdf5.C
+++ b/src/sachdf5.C
@@ -225,19 +225,6 @@ int openWriteData(hid_t loc, const char *name, hid_t type_id, void *data, int nd
 
     /* etime = MPI_Wtime(); */
 
-    /* if (!isIncAzWritten) { */
-/* #ifdef USE_DSET_ATTR */
-    /*   std::string newname = name; */
-    /*   std::string incname = newname + "CMPINC"; */
-    /*   std::string azname  = newname + "CMPAZ"; */
-    /*   openWriteAttr(loc, incname.c_str(), H5T_NATIVE_FLOAT, &cmpinc); */
-    /*   openWriteAttr(loc, azname.c_str(), H5T_NATIVE_FLOAT, &cmpaz); */
-/* #else */
-    /*   openWriteAttr(dset, "CMPINC", H5T_NATIVE_FLOAT, &cmpinc); */
-    /*   openWriteAttr(dset, "CMPAZ", H5T_NATIVE_FLOAT, &cmpaz); */
-/* #endif */
-    /* } */
-
     if (isLast) 
         openWriteAttr(loc, "NPTS", H5T_NATIVE_INT, &total_npts);
 
@@ -248,7 +235,6 @@ int openWriteData(hid_t loc, const char *name, hid_t type_id, void *data, int nd
     /* printf("Rank %d: Attr write time %f, data write time %f\n", myRank, etime1-etime, etime-stime); */
     /* fflush(stdout); */
 
-
     if (is_debug) {
         float *write_data = (float*)data;
         printf("npts=%d, first=%e, second=%e, middle=%e, second last=%e, last=%e\n", 
@@ -257,7 +243,6 @@ int openWriteData(hid_t loc, const char *name, hid_t type_id, void *data, int nd
     }
 
     /* H5Dflush(dset); */
-
     H5Pclose(dxpl);
     if (filespace != H5S_ALL) 
         H5Sclose(filespace);


### PR DESCRIPTION
- Add ZFP compression with SSI output, which buffers a number of steps before applying compression and writing to an HDF5 file
- Add a profile option (disabled by default, enable by running make profile=yes) to Makefile which uses  -g -O3", and without BZ_DEBUG to enable debug symbols while not going through time-consuming out-of-bound Sarray error checking
- Fix a compatibility issue with HDF5 1.12 and later versions.
- Passed all regression tests on Cori and Summit