### PR TITLE
Workaround for checkpoint with ZFP on Summit

### DIFF
--- a/src/TimeSeries.C
+++ b/src/TimeSeries.C
@@ -1365,7 +1365,7 @@ void TimeSeries::readFile( EW *ew, bool ignore_utc )
 //building the file name...
 // 
    stringstream filePrefix;
-   if( ew->getObservationPath(m_global_event) != "./" )
+   if( ew->getObservationPath(m_global_event) != "./" && ew->getObservationPath(m_global_event) != "" )
       filePrefix << ew->getObservationPath(m_global_event);
    else if( mIsRestart )
       filePrefix << ew->getPath() << "/";


### PR DESCRIPTION
Fix HDF5 dataset creation failure on Summit with ZFP, hdf5/1.10.4 and spectrum-mpi/10.3.1.2-20200121
Also fix a file path issue for restart with Time-series data in USGS format.