### PR TITLE
Bug fix

### DIFF
--- a/src/ESSI3D.h
+++ b/src/ESSI3D.h
@@ -99,7 +99,7 @@ protected:
        Sarray& a_Z);
    void close_vel_file();
    void write_image_hdf5( int cycle, std::string& path, float_sw4 t,
-       std::vector<Sarray>& a_U );
+       std::vector<Sarray>& a_U, int is_last );
 #endif
 
    void compute_file_suffix( int cycle, std::stringstream & fileSuffix );

--- a/src/EW.C
+++ b/src/EW.C
@@ -6912,7 +6912,11 @@ void EW::extractTopographyFromSfile( std::string a_topoFileName )
 
   double hh;
   if (m_myRank==0 ) {
-    attr_id = H5Aopen(file_id, "Coarsest horizontal grid spacing", H5P_DEFAULT);
+    // For backward-compatibility
+    if (H5Aexists(file_id, "Coarsest horizontal grid spacing") > 0)
+        attr_id = H5Aopen(file_id, "Coarsest horizontal grid spacing", H5P_DEFAULT);
+    else
+        attr_id = H5Aopen(file_id, "Finest horizontal grid spacing", H5P_DEFAULT);
     ASSERT(attr_id >= 0);
     ierr = H5Aread(attr_id, H5T_NATIVE_DOUBLE, &hh);
     ASSERT(ierr >= 0);

--- a/src/SfileOutput.C
+++ b/src/SfileOutput.C
@@ -718,7 +718,7 @@ void SfileOutput::write_image(const char *fname, std::vector<Sarray>& a_Z )
     H5Awrite(attr, H5T_NATIVE_DOUBLE, lonlataz);
     H5Aclose(attr);
 
-    aname = "Coarsest horizontal grid spacing";
+    aname = "Finest horizontal grid spacing";
     double spacing = mEW->mGridSize[ng-1]*stH;
     attr = H5Acreate(h5_fid, aname, H5T_NATIVE_DOUBLE, attr_space1, H5P_DEFAULT, H5P_DEFAULT);
     if( attr < 0 )


### PR DESCRIPTION
Fix an ssioutput bug that skips the the last few steps ouput when dumpInterval and bufferInterval are both used.
Change sfile attribute name from "Coarsest horizontal grid spacing" to the correct "Finest horizontal grid spacing" (#115)