### PR TITLE
Fix a bug with material model communication, add perlmutter test script

### DIFF
--- a/pytest/test_sw4.py
+++ b/pytest/test_sw4.py
@@ -122,6 +122,7 @@ def guess_mpi_cmd(mpi_tasks, omp_threads, cpu_allocation, verbose):
     if verbose: print('node_name=', node_name)
     sys_name = os.uname()[0]
     if verbose: print('sys_name=', sys_name)
+    nersc_sys = os.getenv('NERSC_HOST')
 
 
     if 'quartz' in node_name:
@@ -144,6 +145,9 @@ def guess_mpi_cmd(mpi_tasks, omp_threads, cpu_allocation, verbose):
         if mpi_tasks<=0: mpi_tasks = int(32/omp_threads) # for Haswell nodes
         sw_threads = omp_threads 
         mpirun_cmd="srun --cpu_bind=cores -n " + str(mpi_tasks) + " -c " + str(sw_threads)
+        # For Perlmutter
+        if nersc_sys == 'perlmutter':
+            mpirun_cmd="srun -N 1 -n 4 -c 32 --gpu-bind=single:1 --cpu-bind=cores  --gpus-per-task=1 "
     elif 'fourier' in node_name:
         if omp_threads<=0: omp_threads=1;
         if mpi_tasks<=0: mpi_tasks = 4

--- a/src/MaterialBlock.C
+++ b/src/MaterialBlock.C
@@ -167,7 +167,7 @@ void MaterialBlock::set_material_properties(std::vector<Sarray>& rho,
 
     // communicate material properties to ghost points (necessary on refined
     // meshes because ghost points don't have a well defined depth/topography)
-    mEW->communicate_array(rho[g], g);
+    mEW->communicate_array_host(rho[g], g);
     mEW->communicate_array_host(cs[g], g);
     mEW->communicate_array_host(cp[g], g);
 
@@ -226,12 +226,12 @@ void MaterialBlock::set_material_properties(std::vector<Sarray>& rho,
           }
         }
       }
-      mEW->communicate_array(rho[g], g);
-      mEW->communicate_array(cs[g], g);
-      mEW->communicate_array(cp[g], g);
+      mEW->communicate_array_host(rho[g], g);
+      mEW->communicate_array_host(cs[g], g);
+      mEW->communicate_array_host(cp[g], g);
 
-      if (qs[g].is_defined()) mEW->communicate_array(qs[g], g);
-      if (qp[g].is_defined()) mEW->communicate_array(qp[g], g);
+      if (qs[g].is_defined()) mEW->communicate_array_host(qs[g], g);
+      if (qp[g].is_defined()) mEW->communicate_array_host(qp[g], g);
     }
   }
   // end if topographyExists

--- a/src/MaterialGMG.C
+++ b/src/MaterialGMG.C
@@ -295,15 +295,15 @@ void MaterialGMG::set_material_properties(std::vector<Sarray>& rho,
   for (int i = 0; i < m_npatches; i++) delete[] m_Material[i];
   delete[] m_Top_surface;
 
-  mEW->communicate_arrays(rho);
-  mEW->communicate_arrays(cs);
-  mEW->communicate_arrays(cp);
+  mEW->communicate_host_arrays(rho);
+  mEW->communicate_host_arrays(cs);
+  mEW->communicate_host_arrays(cp);
   mEW->material_ic(rho);
   mEW->material_ic(cs);
   mEW->material_ic(cp);
   if (use_q) {
-    mEW->communicate_arrays(xis);
-    mEW->communicate_arrays(xip);
+    mEW->communicate_host_arrays(xis);
+    mEW->communicate_host_arrays(xip);
     mEW->material_ic(xis);
     mEW->material_ic(xip);
   }

--- a/src/MaterialRfile.C
+++ b/src/MaterialRfile.C
@@ -300,7 +300,7 @@ void MaterialRfile::set_material_properties(std::vector<Sarray>& rho,
 
   }  // end for g...
 
-  mEW->communicate_arrays(rho);
+  mEW->communicate_host_arrays(rho);
   mEW->communicate_host_arrays(cs);
   mEW->communicate_host_arrays(cp);
 

--- a/src/MaterialSfile.C
+++ b/src/MaterialSfile.C
@@ -316,7 +316,7 @@ void MaterialSfile::set_material_properties(std::vector<Sarray> &rho,
   delete[] ist;
   delete[] jst;
 
-  mEW->communicate_arrays(rho);
+  mEW->communicate_host_arrays(rho);
   mEW->communicate_host_arrays(cs);
   mEW->communicate_host_arrays(cp);
   mEW->material_ic(rho);


### PR DESCRIPTION
The error from Perlmutter is fixed by changing communicate_array() to communicate_array_host(), and communicate_arrays() to communicate_host_arrays(). Also passes all pytest cases.