### PR TITLE
scr: query whether a checkpoint is recommended

### DIFF
--- a/src/CheckPoint.C
+++ b/src/CheckPoint.C
@@ -282,6 +282,18 @@ bool CheckPoint::timeToWrite(float_sw4 time, int cycle, float_sw4 dt) {
   if (cycle == mWritingCycle) do_it = true;
   if (mCycleInterval != 0 && cycle % mCycleInterval == 0 && time >= mStartTime)
     do_it = true;
+
+#ifndef SW4_USE_SCR
+  // FYI: One can optionally ask SCR whether it recommends a checkpoint.
+  // This call isn't required, and one can ignore
+  // the recommendation even if one makes the call.
+  // By default, this always returns false,
+  // but there are various ways to configure SCR to use it.
+  int flag;
+  SCR_Need_checkpoint(&flag);
+  do_it = flag;
+#endif
+
   return do_it;
 }
 


### PR DESCRIPTION
This call is not required, however, this would be a good spot for it.

``SCR_Need_checkpoint`` always returns False unless activated.  Several parameters can be used to configure when it returns True, including:
```
SCR_CHECKPOINT_INTERVAL - checkpoint every Nth time Need_checkpoint is called
SCR_CHECKPOINT_SECONDS - checkpoint after every N seconds
SCR_CHECKPOINT_OVERHEAD - keep checkpoint overhead below N% of runtime
```
As another option that is being developed, this call is meant to be a portable way to guide an application to the optimal checkpoint frequency on a system, depending on the checkpoint costs and failure rates of the system.  SCR knows the checkpoint cost and it can track application failure rates.  Given that data, it can compute the optimal checkpoint frequency using well-known formulas.  This is still being worked out, though it's close enough to try if interested.