### PR TITLE
add option to restart from most recent checkpoint

### DIFF
--- a/src/CheckPoint.C
+++ b/src/CheckPoint.C
@@ -109,6 +109,22 @@ bool CheckPoint::do_checkpointing() { return mDoCheckPointing; }
 int CheckPoint::get_checkpoint_cycle_interval() { return mCycleInterval; }
 
 //-----------------------------------------------------------------------
+// Disable restart if given restartlatest, but no checkpoint is available
+bool CheckPoint::verify_restart() {
+#ifdef SW4_USE_SCR
+  // Check whether SCR loaded a checkpoint.
+  int have_restart = 0;
+  char cycle_num[SCR_MAX_FILENAME];
+  SCR_Have_restart(&have_restart, cycle_num);
+
+  // Disable restart if SCR could not find a checkpoint.
+  if (! have_restart) {
+    mDoRestart = false;
+  }
+#endif
+}
+
+//-----------------------------------------------------------------------
 bool CheckPoint::do_restart() { return mDoRestart; }
 
 //-----------------------------------------------------------------------
@@ -623,19 +639,24 @@ float_sw4 CheckPoint::getDt() {
 #else
 
   int have_restart = 0;
-  char checkpoint_dir[SCR_MAX_FILENAME];
-  SCR_Have_restart(&have_restart, checkpoint_dir);
+  char cycle_num[SCR_MAX_FILENAME];
+  SCR_Have_restart(&have_restart, cycle_num);
   if (! have_restart) {
     std::cerr<<"Error :: SCR found no checkpoints ! \n"<<std::flush;
     abort();
   } 
   
-  SCR_Start_restart(checkpoint_dir);
+  SCR_Start_restart(cycle_num);
   
   std::stringstream s;
-  s<<checkpoint_dir<<"/CheckPoint_"<<mEW->getRank()<<".bin";
+  if (get_restart_path().length()!=0)
+    s<<get_restart_path()<<"/"<<cycle_num<<"/CheckPoint_"<<mEW->getRank()<<".bin";
+  else
+    s<<get_restart_path()<<"./"<<cycle_num<<"CheckPoint_"<<mEW->getRank()<<".bin";
+
   char scr_file[SCR_MAX_FILENAME];
   SCR_Route_file(s.str().c_str(), scr_file);
+
   int valid=1;
   if (std::FILE *file=std::fopen(scr_file,"rb")){
     float_sw4 dt; 
@@ -821,6 +842,13 @@ void CheckPoint::cycle_checkpoints(string CheckPointFile) {
     mCheckPointFileMM = CheckPointFile;
   else if (m_fileno == 2)
     mCheckPointFileM = CheckPointFile;
+}
+
+//-----------------------------------------------------------------------
+// Restart from the most recent chekpoint if available, otherwise start new run
+void CheckPoint::set_restart_latest(size_t bufsize) {
+  m_bufsize = bufsize;
+  mDoRestart = true;
 }
 
 //-----------------------------------------------------------------------

--- a/src/CheckPoint.h
+++ b/src/CheckPoint.h
@@ -24,6 +24,7 @@ class CheckPoint {
              size_t bufsize = 10000000);
   CheckPoint(EW* a_ew, string fname, size_t bufsize = 10000000);
   ~CheckPoint();
+  void set_restart_latest(size_t bufsize);
   void set_restart_file(string fname, size_t bufsize);
   void set_checkpoint_file(string fname, int cycle, int cycleInterval,
                            size_t bufsize, bool useHDF5, int compressionMode,
@@ -66,6 +67,7 @@ void write_checkpoint_scr(float_sw4 a_time, int a_cycle,
   float_sw4 getDt();
   bool do_checkpointing();
   int get_checkpoint_cycle_interval();
+  bool verify_restart();
   bool do_restart();
   void set_restart_path(string restartPath);
   std::string get_restart_path();

--- a/src/EW.C
+++ b/src/EW.C
@@ -733,6 +733,9 @@ EW::EW(const string& fileName, vector<vector<Source*>>& a_GlobalSources,
     // sprintf(fname,"sw4-error-log-p%i.txt", m_myRank);
     // msgStream.open(fname);
 
+  // Potentially disable restart if no checkpoint is found
+  m_check_point->verify_restart();
+
 #if defined(ENABLE_GPU)
   float_sw4* tmpa =
       SW4_NEW(Space::Managed, float_sw4[6 + 384 + 24 + 48 + 6 + 384 + 6 + 6]);

--- a/src/parseInputFile.C
+++ b/src/parseInputFile.C
@@ -3807,6 +3807,9 @@ void EW::processCheckPoint(char* buffer) {
     m_check_point->set_checkpoint_file(filePrefix, cycle, cycleInterval,
                                        bufsize, useHDF5, compressionMode,
                                        compressionPar);
+
+  CHECK_INPUT(!(restartLatestGiven && restartFileGiven),
+              err << "invalid to specify both restartlatest and restartfile");
   if (restartLatestGiven) {
     m_check_point->set_restart_latest(bufsize);
   }

--- a/src/parseInputFile.C
+++ b/src/parseInputFile.C
@@ -3693,7 +3693,7 @@ void EW::processCheckPoint(char* buffer) {
   string filePrefix = "checkpoint";
 
   string restartFileName, restartPath;
-  bool restartFileGiven = false, restartPathGiven = false, useHDF5 = false;
+  bool restartLatestGiven = false, restartFileGiven = false, restartPathGiven = false, useHDF5 = false;
   int compressionMode = 0;
   double compressionPar;
 
@@ -3717,6 +3717,9 @@ void EW::processCheckPoint(char* buffer) {
     } else if (startswith("file=", token)) {
       token += 5;  // skip file=
       filePrefix = token;
+    } else if (startswith("restartlatest", token)) {
+      token += 13;
+      restartLatestGiven = true;
     } else if (startswith("restartfile=", token)) {
       token += 12;  // skip file=
       restartFileName = token;
@@ -3804,6 +3807,9 @@ void EW::processCheckPoint(char* buffer) {
     m_check_point->set_checkpoint_file(filePrefix, cycle, cycleInterval,
                                        bufsize, useHDF5, compressionMode,
                                        compressionPar);
+  if (restartLatestGiven) {
+    m_check_point->set_restart_latest(bufsize);
+  }
   if (restartFileGiven) {
     m_check_point->set_restart_file(restartFileName, bufsize);
   }

--- a/src/solve.C
+++ b/src/solve.C
@@ -332,6 +332,9 @@ void EW::solve(vector<Source*>& a_Sources, vector<TimeSeries*>& a_TimeSeries,
   vector<int> identsources;
   sort_grid_point_sources(point_sources, identsources);
 
+  // Potentially disable restart if no checkpoint is found
+  m_check_point->verify_restart();
+
   // Assign initial data
   int beginCycle;
   float_sw4 t;

--- a/src/solve.C
+++ b/src/solve.C
@@ -332,9 +332,6 @@ void EW::solve(vector<Source*>& a_Sources, vector<TimeSeries*>& a_TimeSeries,
   vector<int> identsources;
   sort_grid_point_sources(point_sources, identsources);
 
-  // Potentially disable restart if no checkpoint is found
-  m_check_point->verify_restart();
-
   // Assign initial data
   int beginCycle;
   float_sw4 t;


### PR DESCRIPTION
Adds a new ``restartlatest`` input file option to enable SW4 to always restart from the most recent checkpoint.  This is currently only valid when using SCR.  SCR identifies the most recent checkpoint available and returns its name, which is currently the simulation cycle number.

This also needs to handle the case where there is no checkpoint.  In that case, we call ``SCR_Have_restart`` and then disable the restart flag if SCR reports that there is no checkpoint available.  SW4 should then run as if the user provided no restart file info.