### PR TITLE
WIP: add SCR to HDF path

### DIFF
--- a/src/CheckPoint.C
+++ b/src/CheckPoint.C
@@ -1368,20 +1368,6 @@ void CheckPoint::read_checkpoint_hdf5(float_sw4& a_time, int& a_cycle,
   MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
   MPI_Comm_size(MPI_COMM_WORLD, &nrank);
 
-#ifdef SW4_USE_SCR
-  // Double check that SCR has a checkpoint loaded
-  int have_restart = 0;
-  char cycle_num[SCR_MAX_FILENAME];
-  SCR_Have_restart(&have_restart, cycle_num);
-  if (! have_restart) {
-    // We expected SCR to have something to get to this point
-    abort();
-  }
-
-  // Get checkpoint name from SCR (we use application cycle number)
-  SCR_Start_restart(cycle_num);
-#endif
-
   std::stringstream s;
   if (mRestartPathSet)
     s << mRestartPath << "/";
@@ -1391,6 +1377,8 @@ void CheckPoint::read_checkpoint_hdf5(float_sw4& a_time, int& a_cycle,
 #ifndef SW4_USE_SCR
   s << mRestartFile;
 #else
+  // TODO: need to get cycle_num from earlier call to Have_restart
+
   // TODO: this is not right, but you get the idea...
   std::stringstream fileSuffix;
   compute_file_suffix(cycle_num, fileSuffix);

--- a/src/CheckPoint.C
+++ b/src/CheckPoint.C
@@ -650,6 +650,45 @@ float_sw4 CheckPoint::getDt() {
   }
   MPI_Bcast(&dt, 1, mEW->m_mpifloat, 0, mEW->m_cartesian_communicator);
   return dt;
+
+#if 0
+  int have_restart = 0;
+  char checkpoint_dir[SCR_MAX_FILENAME];
+  SCR_Have_restart(&have_restart, checkpoint_dir);
+  if (! have_restart) {
+    std::cerr<<"Error :: SCR found no checkpoints ! \n"<<std::flush;
+    abort();
+  } 
+  
+  SCR_Start_restart(checkpoint_dir);
+  
+  std::stringstream s;
+  s<<checkpoint_dir<<"/CheckPoint_"<<mEW->getRank()<<".bin";
+  char scr_file[SCR_MAX_FILENAME];
+  SCR_Route_file(s.str().c_str(), scr_file);
+  int valid=1;
+  if (std::FILE *file=std::fopen(scr_file,"rb")){
+    float_sw4 dt; 
+    if ( std::fread(&dt,sizeof dt,1,file)==1) {
+      scr_file_handle=file;
+      return dt;
+    } else {
+      std::cerr<<"ERROR:: Read of SCR checkpoint file failed in getDt \n"<<std::flush;
+      std::fclose(file);
+      valid = 0;
+    }
+  } else {
+    std::cerr<<"ERROR::Restart file opening failed in getDt "<<s.str()<<"\n"<<std::flush;
+    valid = 0;
+  }
+  
+  if (!valid){
+    std::cerr<<"ERROR :: Invalid restart file "<<s.str()<<"\n Aborting..\n"<<std::flush;
+    abort();
+  }
+  
+  return -1.0e99; // Dummy return to suppress warnings. Should never be reached
+#endif
 }
 
 //-----------------------------------------------------------------------

--- a/src/CheckPoint.C
+++ b/src/CheckPoint.C
@@ -299,6 +299,10 @@ void CheckPoint::compute_file_suffix(int cycle, std::stringstream& fileSuffix) {
   fileSuffix << ".sw4checkpoint";
 }
 
+void CheckPoint::compute_file_suffix(const char* cycle, std::stringstream& fileSuffix) {
+  fileSuffix << mCheckPointFile << "." << cycle << ".sw4checkpoint";
+}
+
 //-----------------------------------------------------------------------
 void CheckPoint::write_checkpoint(float_sw4 a_time, int a_cycle,
                                   vector<Sarray>& a_Um, vector<Sarray>& a_U,
@@ -606,7 +610,7 @@ float_sw4 CheckPoint::getDt() {
     // TODO: this is not right, but you get the idea...
     std::stringstream fileSuffix;
     compute_file_suffix(cycle_num, fileSuffix);
-    s << fileSuffix;
+    s << fileSuffix.str();
 
     // Ask SCR for the path to open our checkpoint file
     char scr_file[SCR_MAX_FILENAME];
@@ -1382,7 +1386,7 @@ void CheckPoint::read_checkpoint_hdf5(float_sw4& a_time, int& a_cycle,
   // TODO: this is not right, but you get the idea...
   std::stringstream fileSuffix;
   compute_file_suffix(cycle_num, fileSuffix);
-  s << fileSuffix;
+  s << fileSuffix.str();
 
   // Ask SCR for the path to open our checkpoint file
   char scr_file[SCR_MAX_FILENAME];

--- a/src/CheckPoint.h
+++ b/src/CheckPoint.h
@@ -75,6 +75,7 @@ void write_checkpoint_scr(float_sw4 a_time, int a_cycle,
   void define_pio();
   void setSteps(int a_steps);
   void compute_file_suffix(int cycle, std::stringstream& fileSuffix);
+  void compute_file_suffix(const char* cycle, std::stringstream& fileSuffix);
   void cycle_checkpoints(string fname);
   void write_header(int& fid, float_sw4 a_time, int a_cycle, int& hsize);
   void read_header(int& fid, float_sw4& a_time, int& a_cycle, int& hsize);


### PR DESCRIPTION
This starts the work to integrate SCR into the (synchronous) HDF checkpoint path.  Since the HDF path writes a single shared file, one would need to run SCR in bypass mode:

```
SCR_CACHE_BYPASS=1
```

This is not yet complete.
- The string manipulation to compute the file suffix needs to be fixed.
- The getDt path for HDF needs to include SCR calls.  I updated getDt to show the SCR calls for HDF, but I dropped the existing SCR getDt code.  That would need to be added back, but we'll need a new compile time guard.

Also updated this PR to include SCR in the non-HDF, single file path.