### PR TITLE
Skip SRF sources with slip_sum=0 and fix sfileoutput

### DIFF
--- a/pytest/verify_hdf5.py
+++ b/pytest/verify_hdf5.py
@@ -79,10 +79,10 @@ def read_sw4img(fname):
     # Grid size info
     h = np.zeros(npatch, dtype=np.float64)
     zmin = np.zeros(npatch, dtype=np.float64)
-    i = np.zeros(npatch, dtype=np.int)
-    ni = np.zeros(npatch, dtype=np.int)
-    j = np.zeros(npatch, dtype=np.int)
-    nj = np.zeros(npatch, dtype=np.int)
+    i = np.zeros(npatch, dtype=int)
+    ni = np.zeros(npatch, dtype=int)
+    j = np.zeros(npatch, dtype=int)
+    nj = np.zeros(npatch, dtype=int)
     nelem = 0
     for u in range (0, npatch):
         h[u] = struct.unpack('d', img.read(8))[0]

--- a/src/EW.C
+++ b/src/EW.C
@@ -7261,7 +7261,8 @@ void EW::extractTopographyFromGMG( std::string a_topoFileName )
     group_id = H5Gopen(file_id, "surfaces", H5P_DEFAULT);
     ASSERT(group_id >= 0);
 
-    dataset_id = open_gmg_surface_dataset(group_id, &surface_name);
+    dataset_id = open_gmg_surface_dataset(group_id, &surface_name,
+                                          GMG_SURFACE_TOPOGRAPHY);
     CHECK_INPUT(dataset_id >= 0,
                 "ERROR: GMG /surfaces must contain one of: top_surface, topography_bathymetry");
 
@@ -7309,10 +7310,13 @@ void EW::extractTopographyFromGMG( std::string a_topoFileName )
                " azimuth on GMG = " << alpha << " azimuth of coordinate sytem = " << mGeoAz << 
                " difference = " << alpha-mGeoAz );
 
-  if (m_myRank==0 && mVerbose >= 2) {
-    printf("GMG header: azimuth=%e, origin_x=%f, origin_y=%f\n", az, origin_x, origin_y);
-    printf("            surface=%s, hx=%e, hy=%e, ni=%lld, nj=%lld\n",
-           surface_name ? surface_name : "broadcast", top_hx, top_hy, dims[0], dims[1]);
+  if (m_myRank == 0 && mVerbose >= 2) {
+    printf("GMG header: azimuth=%e, origin_x=%f, origin_y=%f\n", az, origin_x,
+           origin_y);
+    printf("            surface=%s, hx=%e, hy=%e, ni=%llu, nj=%llu\n",
+           surface_name ? surface_name : "broadcast", top_hx, top_hy,
+           static_cast<unsigned long long>(dims[0]),
+           static_cast<unsigned long long>(dims[1]));
   }
 
   float  *f_data = new float[dims[0] * dims[1]];
@@ -7329,7 +7333,10 @@ void EW::extractTopographyFromGMG( std::string a_topoFileName )
   // Topography read, next interpolate to the computational grid
   int topLevel=mNumberOfGrids-1;
 
-  float_sw4 topomax=-1e30, topomin=1e30;
+  float_sw4 topomax = -1e30, topomin = 1e30;
+  double gmg_x_min = 1e100, gmg_x_max = -1e100;
+  double gmg_y_min = 1e100, gmg_y_max = -1e100;
+  long long outside_gmg_surface = 0;
 
   /* printf("x0=%f, y0=%f\n", x0, y0); */
   /* printf("topoGMG: m_iStart %d, m_iEnd %d, m_jStart %d, m_jEnd %d\n", */ 
@@ -7356,14 +7363,25 @@ void EW::extractTopographyFromGMG( std::string a_topoFileName )
   
       const double xRel = gmg_x0 - origin_x;
       const double yRel = gmg_y0 - origin_y;
-      gmg_x = xRel*cosAz - yRel*sinAz;
-      gmg_y = xRel*sinAz + yRel*cosAz;
-      /* printf("converted gmg xy: %f, %f, origin: %f %f\n", gmg_x, gmg_y, origin_x, origin_y); */
-  
+      gmg_x = xRel * cosAz - yRel * sinAz;
+      gmg_y = xRel * sinAz + yRel * cosAz;
+      /* printf("converted gmg xy: %f, %f, origin: %f %f\n", gmg_x, gmg_y,
+       * origin_x, origin_y); */
+
+      if (gmg_x < gmg_x_min) gmg_x_min = gmg_x;
+      if (gmg_x > gmg_x_max) gmg_x_max = gmg_x;
+      if (gmg_y < gmg_y_min) gmg_y_min = gmg_y;
+      if (gmg_y > gmg_y_max) gmg_y_max = gmg_y;
+
       const double xmax = (dims[0] - 1) * top_hx;
       const double ymax = (dims[1] - 1) * top_hy;
-      const double gmg_x_clamped = std::max(0.0, std::min(gmg_x, xmax));
-      const double gmg_y_clamped = std::max(0.0, std::min(gmg_y, ymax));
+      const double tol =
+          std::max(1e-6 * std::max(top_hx, top_hy),
+                   1e-10 * std::max(xmax, ymax));
+      const double gmg_x_clamped =
+          gmg_clamp_coordinate(gmg_x, 0.0, xmax, tol, outside_gmg_surface);
+      const double gmg_y_clamped =
+          gmg_clamp_coordinate(gmg_y, 0.0, ymax, tol, outside_gmg_surface);
 
       int i0 = static_cast<int>( floor(gmg_x_clamped/top_hx) );
       int j0 = static_cast<int>( floor(gmg_y_clamped/top_hy) );
@@ -7400,14 +7418,41 @@ void EW::extractTopographyFromGMG( std::string a_topoFileName )
   MPI_Barrier(m_1d_communicator);
   end_time = MPI_Wtime();
 
-  if (m_myRank==0) {
-    printf("Read topography from GeoModelGrids time=%e seconds\n", end_time-start_time);
-    if (mVerbose>=2) {
-      printf("Topo corners %f, %f, %f, %f\n", mTopo(m_iStart[topLevel],m_jStart[topLevel],1), mTopo(m_iEnd[topLevel],m_jStart[topLevel],1),
-                                              mTopo(m_iEnd[topLevel],m_jStart[topLevel],1), mTopo(m_iEnd[topLevel],m_jEnd[topLevel],1));
+  double gmg_x_min_global, gmg_x_max_global, gmg_y_min_global,
+      gmg_y_max_global;
+  long long outside_gmg_surface_global;
+  MPI_Allreduce(&gmg_x_min, &gmg_x_min_global, 1, MPI_DOUBLE, MPI_MIN,
+                m_1d_communicator);
+  MPI_Allreduce(&gmg_x_max, &gmg_x_max_global, 1, MPI_DOUBLE, MPI_MAX,
+                m_1d_communicator);
+  MPI_Allreduce(&gmg_y_min, &gmg_y_min_global, 1, MPI_DOUBLE, MPI_MIN,
+                m_1d_communicator);
+  MPI_Allreduce(&gmg_y_max, &gmg_y_max_global, 1, MPI_DOUBLE, MPI_MAX,
+                m_1d_communicator);
+  MPI_Allreduce(&outside_gmg_surface, &outside_gmg_surface_global, 1,
+                MPI_LONG_LONG, MPI_SUM, m_1d_communicator);
+
+  if (m_myRank == 0) {
+    printf("Read topography from GeoModelGrids time=%e seconds\n",
+           end_time - start_time);
+    printf("GMG topography projected bounds: x=[%e,%e], y=[%e,%e]\n",
+           gmg_x_min_global, gmg_x_max_global, gmg_y_min_global,
+           gmg_y_max_global);
+    if (mVerbose >= 2) {
+      printf("Topo corners %f, %f, %f, %f\n",
+             mTopo(m_iStart[topLevel], m_jStart[topLevel], 1),
+             mTopo(m_iEnd[topLevel], m_jStart[topLevel], 1),
+             mTopo(m_iEnd[topLevel], m_jStart[topLevel], 1),
+             mTopo(m_iEnd[topLevel], m_jEnd[topLevel], 1));
       printf("Topo variation on comp grid: max=%e min=%e\n", topomax, topomin);
     }
   }
+  CHECK_INPUT(
+      outside_gmg_surface_global == 0,
+      "ERROR: GMG topography projection maps "
+          << outside_gmg_surface_global
+          << " grid coordinates outside the surface extent. "
+          << "Check CRS, axis order, origin, and azimuth.");
 #else
   if (m_myRank==0)
     printf("WARNING: sw4 not compiled with hdf5=yes, ignoring read GMG, abort!\n");

--- a/src/EW.C
+++ b/src/EW.C
@@ -7351,8 +7351,7 @@ void EW::extractTopographyFromGMG( std::string a_topoFileName )
       computeGeographicCoord(x, y, sw4_lon, sw4_lat);
       /* printf("\ncomputeGeographicCoord: %f %f %f %f\n", x, y, sw4_lon, sw4_lat); */
 
-      // GMG x/y, lat/lon is switched from sw4 CRS
-      computeCartesianCoordGMG(gmg_y0, gmg_x0, sw4_lon, sw4_lat, crs_to);
+      computeCartesianCoordGMG(gmg_x0, gmg_y0, sw4_lon, sw4_lat, crs_to);
       /* printf("computeCartesianCoordGMG : %f %f %f %f\n", gmg_x0, gmg_y0, sw4_lon, sw4_lat); */
   
       const double xRel = gmg_x0 - origin_x;

--- a/src/EW.C
+++ b/src/EW.C
@@ -7229,56 +7229,7 @@ static char* read_hdf5_attr_str(hid_t loc, const char *name)
   /* fprintf(stderr, "Read data: [%s]\n", data); */
   return data;
 }
-
-static bool read_hdf5_attr_optional_f64(hid_t loc, const char* name,
-                                        double& data)
-{
-  if (H5Aexists(loc, name) <= 0)
-    return false;
-  read_hdf5_attr(loc, H5T_IEEE_F64LE, name, &data);
-  return true;
-}
-
-static void read_gmg_surface_spacing(hid_t dataset_id, double& hx, double& hy)
-{
-  double h = 0.0;
-  const bool has_h =
-      read_hdf5_attr_optional_f64(dataset_id, "resolution_horiz", h);
-  const bool has_hx =
-      read_hdf5_attr_optional_f64(dataset_id, "x_resolution", hx);
-  const bool has_hy =
-      read_hdf5_attr_optional_f64(dataset_id, "y_resolution", hy);
-
-  CHECK_INPUT(has_h || (has_hx && has_hy),
-              "ERROR: GMG surface dataset must define resolution_horiz or "
-              "both x_resolution and y_resolution");
-
-  if (!has_hx)
-    hx = h;
-  if (!has_hy)
-    hy = h;
-
-  CHECK_INPUT(hx > 0 && hy > 0,
-              "ERROR: GMG surface spacing must be positive, got hx="
-                  << hx << " hy=" << hy);
-}
-
-static hid_t open_gmg_surface_dataset(hid_t group_id,
-                                      const char** surface_name)
-{
-  const char* candidates[] = {"top_surface", "topography_bathymetry"};
-  const int ncandidates = sizeof(candidates) / sizeof(candidates[0]);
-
-  for (int i = 0; i < ncandidates; i++) {
-    if (H5Lexists(group_id, candidates[i], H5P_DEFAULT) > 0) {
-      if (surface_name)
-        *surface_name = candidates[i];
-      return H5Dopen(group_id, candidates[i], H5P_DEFAULT);
-    }
-  }
-
-  return -1;
-}
+#include "GMGHDF5Helpers.h"
 #endif
 
 //-----------------------------------------------------------------------
@@ -7289,8 +7240,8 @@ void EW::extractTopographyFromGMG( std::string a_topoFileName )
 #ifdef USE_HDF5
   Sarray gridElev;
   herr_t ierr;
-  hid_t file_id, dataset_id, datatype_id, group_id, dataspace_id;
-  int prec, str_len, top_rank = 0;
+  hid_t file_id, dataset_id, datatype_id, group_id;
+  int prec, str_len;
   double az=0, origin_x=0, origin_y=0, top_hx=0, top_hy=0, alpha=0;
   hsize_t dims[3];
   const char* surface_name = NULL;
@@ -7314,17 +7265,7 @@ void EW::extractTopographyFromGMG( std::string a_topoFileName )
     CHECK_INPUT(dataset_id >= 0,
                 "ERROR: GMG /surfaces must contain one of: top_surface, topography_bathymetry");
 
-    dataspace_id = H5Dget_space(dataset_id);
-    top_rank = H5Sget_simple_extent_ndims(dataspace_id);
-    CHECK_INPUT(top_rank == 2 || top_rank == 3,
-                "ERROR: GMG surface dataset must be rank-2 or rank-3, got "
-                    << top_rank);
-    H5Sget_simple_extent_dims(dataspace_id, dims, NULL);
-    if (top_rank == 3)
-      CHECK_INPUT(dims[2] == 1,
-                  "ERROR: GMG surface dataset third dimension must be 1, got "
-                      << dims[2]);
-    H5Sclose(dataspace_id);
+    read_gmg_surface_dims(dataset_id, dims);
 
     datatype_id = H5Dget_type(dataset_id);
     prec = (int)H5Tget_size(datatype_id);

--- a/src/EW.C
+++ b/src/EW.C
@@ -7229,6 +7229,56 @@ static char* read_hdf5_attr_str(hid_t loc, const char *name)
   /* fprintf(stderr, "Read data: [%s]\n", data); */
   return data;
 }
+
+static bool read_hdf5_attr_optional_f64(hid_t loc, const char* name,
+                                        double& data)
+{
+  if (H5Aexists(loc, name) <= 0)
+    return false;
+  read_hdf5_attr(loc, H5T_IEEE_F64LE, name, &data);
+  return true;
+}
+
+static void read_gmg_surface_spacing(hid_t dataset_id, double& hx, double& hy)
+{
+  double h = 0.0;
+  const bool has_h =
+      read_hdf5_attr_optional_f64(dataset_id, "resolution_horiz", h);
+  const bool has_hx =
+      read_hdf5_attr_optional_f64(dataset_id, "x_resolution", hx);
+  const bool has_hy =
+      read_hdf5_attr_optional_f64(dataset_id, "y_resolution", hy);
+
+  CHECK_INPUT(has_h || (has_hx && has_hy),
+              "ERROR: GMG surface dataset must define resolution_horiz or "
+              "both x_resolution and y_resolution");
+
+  if (!has_hx)
+    hx = h;
+  if (!has_hy)
+    hy = h;
+
+  CHECK_INPUT(hx > 0 && hy > 0,
+              "ERROR: GMG surface spacing must be positive, got hx="
+                  << hx << " hy=" << hy);
+}
+
+static hid_t open_gmg_surface_dataset(hid_t group_id,
+                                      const char** surface_name)
+{
+  const char* candidates[] = {"top_surface", "topography_bathymetry"};
+  const int ncandidates = sizeof(candidates) / sizeof(candidates[0]);
+
+  for (int i = 0; i < ncandidates; i++) {
+    if (H5Lexists(group_id, candidates[i], H5P_DEFAULT) > 0) {
+      if (surface_name)
+        *surface_name = candidates[i];
+      return H5Dopen(group_id, candidates[i], H5P_DEFAULT);
+    }
+  }
+
+  return -1;
+}
 #endif
 
 //-----------------------------------------------------------------------
@@ -7237,13 +7287,13 @@ void EW::extractTopographyFromGMG( std::string a_topoFileName )
   double start_time, end_time;
   start_time = MPI_Wtime();
 #ifdef USE_HDF5
-  int verbose = mVerbose;
   Sarray gridElev;
   herr_t ierr;
   hid_t file_id, dataset_id, datatype_id, group_id, dataspace_id;
-  int prec, str_len;
-  double az=0, origin_x=0, origin_y=0, hh=0, alpha=0, lon0=0, lat0=0;
-  hsize_t dims[2];
+  int prec, str_len, top_rank = 0;
+  double az=0, origin_x=0, origin_y=0, top_hx=0, top_hy=0, alpha=0;
+  hsize_t dims[3];
+  const char* surface_name = NULL;
   char *crs_to = NULL;
 
   if (m_myRank == 0) {
@@ -7260,18 +7310,27 @@ void EW::extractTopographyFromGMG( std::string a_topoFileName )
     group_id = H5Gopen(file_id, "surfaces", H5P_DEFAULT);
     ASSERT(group_id >= 0);
 
-    dataset_id = H5Dopen(group_id, "topography_bathymetry", H5P_DEFAULT);
-    ASSERT(dataset_id >= 0);
+    dataset_id = open_gmg_surface_dataset(group_id, &surface_name);
+    CHECK_INPUT(dataset_id >= 0,
+                "ERROR: GMG /surfaces must contain one of: top_surface, topography_bathymetry");
 
     dataspace_id = H5Dget_space(dataset_id);
+    top_rank = H5Sget_simple_extent_ndims(dataspace_id);
+    CHECK_INPUT(top_rank == 2 || top_rank == 3,
+                "ERROR: GMG surface dataset must be rank-2 or rank-3, got "
+                    << top_rank);
     H5Sget_simple_extent_dims(dataspace_id, dims, NULL);
+    if (top_rank == 3)
+      CHECK_INPUT(dims[2] == 1,
+                  "ERROR: GMG surface dataset third dimension must be 1, got "
+                      << dims[2]);
     H5Sclose(dataspace_id);
 
     datatype_id = H5Dget_type(dataset_id);
     prec = (int)H5Tget_size(datatype_id);
     H5Tclose(datatype_id);
 
-    read_hdf5_attr(dataset_id, H5T_IEEE_F64LE, "resolution_horiz", &hh);
+    read_gmg_surface_spacing(dataset_id, top_hx, top_hy);
 
     crs_to = read_hdf5_attr_str(file_id, "crs");
     str_len = (int)(strlen(crs_to)+1);
@@ -7280,8 +7339,9 @@ void EW::extractTopographyFromGMG( std::string a_topoFileName )
   MPI_Bcast(&origin_x, 1, MPI_DOUBLE, 0, m_1d_communicator);
   MPI_Bcast(&origin_y, 1, MPI_DOUBLE, 0, m_1d_communicator);
   MPI_Bcast(&az,       1, MPI_DOUBLE, 0, m_1d_communicator);
-  MPI_Bcast(&hh,       1, MPI_DOUBLE, 0, m_1d_communicator);
-  MPI_Bcast(dims,      2, MPI_LONG_LONG, 0, m_1d_communicator );
+  MPI_Bcast(&top_hx,   1, MPI_DOUBLE, 0, m_1d_communicator);
+  MPI_Bcast(&top_hy,   1, MPI_DOUBLE, 0, m_1d_communicator);
+  MPI_Bcast(dims,      3, MPI_LONG_LONG, 0, m_1d_communicator );
   MPI_Bcast(&prec,     1, MPI_INT, 0, m_1d_communicator );
   MPI_Bcast(&str_len,  1, MPI_INT, 0, m_1d_communicator );
 
@@ -7290,16 +7350,16 @@ void EW::extractTopographyFromGMG( std::string a_topoFileName )
 
   MPI_Bcast(crs_to, str_len, MPI_CHAR, 0, m_1d_communicator );
 
-  // For some reason origin_x is not correctly read sometimes
-  if (origin_x < 1.0) {
-    origin_x = 99286.2;
-    if (m_myRank == 0)
-      printf("GMG origin_x read zero value, correct to 99286.2 \n");
-  }
-
-  ASSERT(origin_x > 0);
-  ASSERT(origin_y > 0);
-  ASSERT(az > 0);
+  CHECK_INPUT(origin_x > 0 && origin_y > 0,
+              "ERROR: invalid GMG origin values origin_x="
+                  << origin_x << " origin_y=" << origin_y);
+  CHECK_INPUT(az > 0, "ERROR: invalid GMG y_azimuth " << az);
+  CHECK_INPUT(top_hx > 0 && top_hy > 0,
+              "ERROR: invalid GMG surface spacing hx="
+                  << top_hx << " hy=" << top_hy);
+  CHECK_INPUT(dims[0] > 1 && dims[1] > 1,
+              "ERROR: GMG surface dataset must be at least 2x2 for interpolation, got "
+                  << dims[0] << "x" << dims[1]);
 
   // Convert GMG az to SW4 az
   alpha = az - 180.0;
@@ -7310,7 +7370,8 @@ void EW::extractTopographyFromGMG( std::string a_topoFileName )
 
   if (m_myRank==0 && mVerbose >= 2) {
     printf("GMG header: azimuth=%e, origin_x=%f, origin_y=%f\n", az, origin_x, origin_y);
-    printf("            hh=%e, ni=%lld, nj=%lld\n", hh, dims[0], dims[1]);
+    printf("            surface=%s, hx=%e, hy=%e, ni=%lld, nj=%lld\n",
+           surface_name ? surface_name : "broadcast", top_hx, top_hy, dims[0], dims[1]);
   }
 
   float  *f_data = new float[dims[0] * dims[1]];
@@ -7359,11 +7420,20 @@ void EW::extractTopographyFromGMG( std::string a_topoFileName )
       gmg_y = xRel*sinAz + yRel*cosAz;
       /* printf("converted gmg xy: %f, %f, origin: %f %f\n", gmg_x, gmg_y, origin_x, origin_y); */
   
-      int i0 = static_cast<int>( floor(gmg_x/hh) );
-      int j0 = static_cast<int>( floor(gmg_y/hh) );
+      const double xmax = (dims[0] - 1) * top_hx;
+      const double ymax = (dims[1] - 1) * top_hy;
+      const double gmg_x_clamped = std::max(0.0, std::min(gmg_x, xmax));
+      const double gmg_y_clamped = std::max(0.0, std::min(gmg_y, ymax));
 
-      double fac0 = (gmg_y - j0 * hh) / hh;
-      double fac1 = (gmg_x - i0 * hh) / hh;
+      int i0 = static_cast<int>( floor(gmg_x_clamped/top_hx) );
+      int j0 = static_cast<int>( floor(gmg_y_clamped/top_hy) );
+      if (i0 >= static_cast<int>(dims[0]) - 1)
+        i0 = dims[0] - 2;
+      if (j0 >= static_cast<int>(dims[1]) - 1)
+        j0 = dims[1] - 2;
+
+      double fac0 = (gmg_y_clamped - j0 * top_hy) / top_hy;
+      double fac1 = (gmg_x_clamped - i0 * top_hx) / top_hx;
 
       /* printf("x=%f, y=%f, i0=%d, j0=%d\n", x, y, i0, j0); */
       /* printf("interp points: %f %f %f %f\n", f_data[i0*dims[1]+j0], f_data[(i0+1)*dims[1]+j0], f_data[i0*dims[1]+j0+1], f_data[(i0+1)*dims[1]+j0+1]); */

--- a/src/GMGHDF5Helpers.h
+++ b/src/GMGHDF5Helpers.h
@@ -1,7 +1,10 @@
 #ifndef SW4_GMGHDF5HELPERS_H
 #define SW4_GMGHDF5HELPERS_H
 
+#include "Require.h"
+
 #ifdef USE_HDF5
+#include "hdf5.h"
 
 static inline bool read_hdf5_attr_optional_f64(hid_t loc, const char* name,
                                                double& data)

--- a/src/GMGHDF5Helpers.h
+++ b/src/GMGHDF5Helpers.h
@@ -3,6 +3,20 @@
 
 #include "Require.h"
 
+static inline double gmg_clamp_coordinate(double value, double lower,
+                                          double upper, double tolerance,
+                                          long long& outside_count) {
+  if (value < lower) {
+    if (lower - value > tolerance) outside_count++;
+    return lower;
+  }
+  if (value > upper) {
+    if (value - upper > tolerance) outside_count++;
+    return upper;
+  }
+  return value;
+}
+
 #ifdef USE_HDF5
 #include "hdf5.h"
 
@@ -45,11 +59,23 @@ static inline void read_gmg_surface_spacing(hid_t dataset_id, double& hx,
                   << hx << " hy=" << hy);
 }
 
+enum GMGSurfacePurpose {
+  GMG_SURFACE_TOPOGRAPHY,
+  GMG_SURFACE_MODEL_TOP
+};
+
 static inline hid_t open_gmg_surface_dataset(hid_t group_id,
-                                             const char** surface_name)
+                                             const char** surface_name,
+                                             GMGSurfacePurpose purpose)
 {
-  const char* candidates[] = {"top_surface", "topography_bathymetry"};
-  const int ncandidates = sizeof(candidates) / sizeof(candidates[0]);
+  const char* topography_candidates[] = {"topography_bathymetry",
+                                         "top_surface"};
+  const char* model_top_candidates[] = {"top_surface",
+                                        "topography_bathymetry"};
+  const char** candidates = purpose == GMG_SURFACE_TOPOGRAPHY
+                                ? topography_candidates
+                                : model_top_candidates;
+  const int ncandidates = 2;
 
   for (int i = 0; i < ncandidates; i++) {
     if (H5Lexists(group_id, candidates[i], H5P_DEFAULT) > 0) {

--- a/src/GMGHDF5Helpers.h
+++ b/src/GMGHDF5Helpers.h
@@ -1,0 +1,88 @@
+#ifndef SW4_GMGHDF5HELPERS_H
+#define SW4_GMGHDF5HELPERS_H
+
+#ifdef USE_HDF5
+
+static inline bool read_hdf5_attr_optional_f64(hid_t loc, const char* name,
+                                               double& data)
+{
+  if (H5Aexists(loc, name) <= 0)
+    return false;
+
+  hid_t attr_id = H5Aopen(loc, name, H5P_DEFAULT);
+  ASSERT(attr_id >= 0);
+  int ierr = H5Aread(attr_id, H5T_IEEE_F64LE, &data);
+  ASSERT(ierr >= 0);
+  H5Aclose(attr_id);
+  return true;
+}
+
+static inline void read_gmg_surface_spacing(hid_t dataset_id, double& hx,
+                                            double& hy)
+{
+  double h = 0.0;
+  const bool has_h =
+      read_hdf5_attr_optional_f64(dataset_id, "resolution_horiz", h);
+  const bool has_hx =
+      read_hdf5_attr_optional_f64(dataset_id, "x_resolution", hx);
+  const bool has_hy =
+      read_hdf5_attr_optional_f64(dataset_id, "y_resolution", hy);
+
+  CHECK_INPUT(has_h || (has_hx && has_hy),
+              "ERROR: GMG surface dataset must define resolution_horiz or "
+              "both x_resolution and y_resolution");
+
+  if (!has_hx)
+    hx = h;
+  if (!has_hy)
+    hy = h;
+
+  CHECK_INPUT(hx > 0 && hy > 0,
+              "ERROR: GMG surface spacing must be positive, got hx="
+                  << hx << " hy=" << hy);
+}
+
+static inline hid_t open_gmg_surface_dataset(hid_t group_id,
+                                             const char** surface_name)
+{
+  const char* candidates[] = {"top_surface", "topography_bathymetry"};
+  const int ncandidates = sizeof(candidates) / sizeof(candidates[0]);
+
+  for (int i = 0; i < ncandidates; i++) {
+    if (H5Lexists(group_id, candidates[i], H5P_DEFAULT) > 0) {
+      if (surface_name)
+        *surface_name = candidates[i];
+      return H5Dopen(group_id, candidates[i], H5P_DEFAULT);
+    }
+  }
+
+  return -1;
+}
+
+static inline int read_gmg_surface_dims(hid_t dataset_id, hsize_t dims[3])
+{
+  dims[0] = 0;
+  dims[1] = 0;
+  dims[2] = 1;
+
+  hid_t dataspace_id = H5Dget_space(dataset_id);
+  ASSERT(dataspace_id >= 0);
+
+  const int top_rank = H5Sget_simple_extent_ndims(dataspace_id);
+  CHECK_INPUT(top_rank == 2 || top_rank == 3,
+              "ERROR: GMG surface dataset must be rank-2 or rank-3, got "
+                  << top_rank);
+
+  H5Sget_simple_extent_dims(dataspace_id, dims, NULL);
+  if (top_rank == 3)
+    CHECK_INPUT(dims[2] == 1,
+                "ERROR: GMG surface dataset third dimension must be 1, got "
+                    << dims[2]);
+
+  H5Sclose(dataspace_id);
+  return top_rank;
+}
+
+#endif
+
+#endif

--- a/src/GeographicProjection.C
+++ b/src/GeographicProjection.C
@@ -43,6 +43,22 @@ static const char* sw4_geographic_crs()
    return "+proj=latlong +datum=NAD83";
 }
 
+#ifdef ENABLE_PROJ
+static PJ* create_lonlat_xy_transform(const char* crs_from,
+                                      const char* crs_to)
+{
+  PJ* transform = proj_create_crs_to_crs(PJ_DEFAULT_CTX, crs_from, crs_to, NULL);
+  if (transform == NULL)
+    return NULL;
+  PJ* normalized = proj_normalize_for_visualization(PJ_DEFAULT_CTX, transform);
+  if (normalized != NULL) {
+    proj_destroy(transform);
+    transform = normalized;
+  }
+  return transform;
+}
+#endif
+
 //-----------------------------------------------------------------------
 GeographicProjection::GeographicProjection( double lon_origin, double lat_origin,
 					    string projection, double az )
@@ -75,7 +91,7 @@ GeographicProjection::GeographicProjection( double lon_origin, double lat_origin
    const char *crs_from = m_geographic_crs.c_str();
    const char *crs_to = projection.c_str();
 
-   m_P = proj_create_crs_to_crs(PJ_DEFAULT_CTX, crs_from, crs_to, NULL);
+   m_P = create_lonlat_xy_transform(crs_from, crs_to);
    /* printf("projection: [%s]\n", crs_to); */
    ASSERT(m_P);
 
@@ -196,9 +212,8 @@ void GeographicProjection::computeCartesianCoordGMG(double &x, double &y,
 
   if (m_Pgmg == NULL || m_gmg_crs_from_cache != m_geographic_crs ||
       m_gmg_crs_to_cache != gmg_crs_to) {
-    if (m_Pgmg)
-      proj_destroy(m_Pgmg);
-    m_Pgmg = proj_create_crs_to_crs(PJ_DEFAULT_CTX, crs_from, gmg_crs_to.c_str(), NULL);
+    if (m_Pgmg) proj_destroy(m_Pgmg);
+    m_Pgmg = create_lonlat_xy_transform(crs_from, gmg_crs_to.c_str());
     m_gmg_crs_from_cache = m_geographic_crs;
     m_gmg_crs_to_cache = gmg_crs_to;
   }

--- a/src/GeographicProjection.C
+++ b/src/GeographicProjection.C
@@ -205,8 +205,7 @@ void GeographicProjection::computeCartesianCoordGMG(double &x, double &y,
 
   ASSERT(m_Pgmg);
 
-  // lat lon is switched in GMG CRS
-  c = proj_coord(lat, lon, 0.0, 0.0);
+  c = proj_coord(lon, lat, 0.0, 0.0);
   c_out = proj_trans(m_Pgmg, PJ_FWD, c);
 
   x = c_out.xyzt.y;

--- a/src/GeographicProjection.C
+++ b/src/GeographicProjection.C
@@ -208,8 +208,8 @@ void GeographicProjection::computeCartesianCoordGMG(double &x, double &y,
   c = proj_coord(lon, lat, 0.0, 0.0);
   c_out = proj_trans(m_Pgmg, PJ_FWD, c);
 
-  x = c_out.xyzt.y;
-  y = c_out.xyzt.x;
+  x = c_out.xyzt.x;
+  y = c_out.xyzt.y;
 
 #else
   printf("GMG format only works with proj 6+, abort!\n");

--- a/src/GeographicProjection.C
+++ b/src/GeographicProjection.C
@@ -38,10 +38,18 @@
 
 using namespace std;
 
+static const char* sw4_geographic_crs()
+{
+   return "+proj=latlong +datum=NAD83";
+}
+
 //-----------------------------------------------------------------------
 GeographicProjection::GeographicProjection( double lon_origin, double lat_origin,
 					    string projection, double az )
 {
+   m_geographic_crs = sw4_geographic_crs();
+   m_gmg_crs_from_cache.clear();
+   m_gmg_crs_to_cache.clear();
 /* #ifdef ENABLE_PROJ4 */
 /*    m_projection = pj_init_plus(projection.c_str()); */
 /*    CHECK_INPUT( m_projection != 0, "ERRROR: Init of cartographic projection failed with message: " << pj_strerrno(pj_errno) ); */
@@ -64,7 +72,7 @@ GeographicProjection::GeographicProjection( double lon_origin, double lat_origin
 
 #ifdef ENABLE_PROJ
    PJ_COORD c, c_out;
-   const char *crs_from = "+proj=latlong +datum=NAD83";
+   const char *crs_from = m_geographic_crs.c_str();
    const char *crs_to = projection.c_str();
 
    m_P = proj_create_crs_to_crs(PJ_DEFAULT_CTX, crs_from, crs_to, NULL);
@@ -179,13 +187,21 @@ void GeographicProjection::computeCartesianCoordGMG(double &x, double &y,
   x = 0.0, y = 0.0;
 #ifdef ENABLE_PROJ
   PJ_COORD c, c_out;
+  const char *crs_from = m_geographic_crs.c_str();
+  const string gmg_crs_to = crs_to ? string(crs_to) : string();
 
-  const char *crs_from = "EPSG:4326";
+  CHECK_INPUT(!gmg_crs_to.empty(), "ERROR: empty GMG target coordinate reference system");
 
   /* printf("computeCartesianCoordGMG: crs_to %s\n", crs_to); */
 
-  if (m_Pgmg == NULL)
-    m_Pgmg  = proj_create_crs_to_crs(PJ_DEFAULT_CTX, crs_from, crs_to, NULL);
+  if (m_Pgmg == NULL || m_gmg_crs_from_cache != m_geographic_crs ||
+      m_gmg_crs_to_cache != gmg_crs_to) {
+    if (m_Pgmg)
+      proj_destroy(m_Pgmg);
+    m_Pgmg = proj_create_crs_to_crs(PJ_DEFAULT_CTX, crs_from, gmg_crs_to.c_str(), NULL);
+    m_gmg_crs_from_cache = m_geographic_crs;
+    m_gmg_crs_to_cache = gmg_crs_to;
+  }
 
   ASSERT(m_Pgmg);
 

--- a/src/GeographicProjection.h
+++ b/src/GeographicProjection.h
@@ -59,6 +59,9 @@ class GeographicProjection
    PJ *m_P;
    PJ *m_Pgmg;
 #endif
+   std::string m_geographic_crs;
+   std::string m_gmg_crs_from_cache;
+   std::string m_gmg_crs_to_cache;
    double m_xoffset, m_yoffset, m_az, m_deg2rad;
 };
 

--- a/src/MaterialGMG.C
+++ b/src/MaterialGMG.C
@@ -44,6 +44,7 @@
 #include <math.h>
 #include <fcntl.h>
 #include "EW.h"
+#include "GMGHDF5Helpers.h"
 #include "MaterialGMG.h"
 #include "Byteswapper.h"
 
@@ -89,10 +90,18 @@ void MaterialGMG::set_material_properties(std::vector<Sarray> & rho,
 // Assume attenuation arrays defined on all grids if they are defined on grid zero.
    bool use_q = m_use_attenuation && xis[0].is_defined() && xip[0].is_defined();
    size_t outside=0, material=0;
+  long long outside_gmg_horizontal = 0;
+  double gmg_x_min = 1e100, gmg_x_max = -1e100;
+  double gmg_y_min = 1e100, gmg_y_max = -1e100;
 
   const double yazimuthRad = m_Yaz * M_PI / 180.0;
   const double cosAz = cos(yazimuthRad);
   const double sinAz = sin(yazimuthRad);
+  const double top_xmax = (m_Top_dims[0] - 1) * m_Top_hx;
+  const double top_ymax = (m_Top_dims[1] - 1) * m_Top_hy;
+  const double top_tol =
+      std::max(1e-6 * std::max(m_Top_hx, m_Top_hy),
+               1e-10 * std::max(top_xmax, top_ymax));
 
   for( int g=0 ; g < mEW->mNumberOfGrids ; g++ ) {
     bool curvilinear = mEW->topographyExists() && g >= mEW->mNumberOfCartesianGrids;
@@ -115,17 +124,22 @@ void MaterialGMG::set_material_properties(std::vector<Sarray> & rho,
           gmg_x = xRel*cosAz - yRel*sinAz;
           gmg_y = xRel*sinAz + yRel*cosAz;
 
+        if (gmg_x < gmg_x_min) gmg_x_min = gmg_x;
+        if (gmg_x > gmg_x_max) gmg_x_max = gmg_x;
+        if (gmg_y < gmg_y_min) gmg_y_min = gmg_y;
+        if (gmg_y > gmg_y_max) gmg_y_max = gmg_y;
 
-          int top_i = static_cast<int>(floor(gmg_x/m_Top_hx));
-          int top_j = static_cast<int>(floor(gmg_y/m_Top_hy));
-          if (top_i < 0)
-            top_i = 0;
-          else if (top_i >= static_cast<int>(m_Top_dims[0]))
-            top_i = static_cast<int>(m_Top_dims[0]) - 1;
-          if (top_j < 0)
-            top_j = 0;
-          else if (top_j >= static_cast<int>(m_Top_dims[1]))
-            top_j = static_cast<int>(m_Top_dims[1]) - 1;
+        double top_x = gmg_clamp_coordinate(gmg_x, 0.0, top_xmax, top_tol,
+                                            outside_gmg_horizontal);
+        double top_y = gmg_clamp_coordinate(gmg_y, 0.0, top_ymax, top_tol,
+                                            outside_gmg_horizontal);
+
+        int top_i = static_cast<int>(floor(top_x / m_Top_hx));
+        int top_j = static_cast<int>(floor(top_y / m_Top_hy));
+        if (top_i >= static_cast<int>(m_Top_dims[0]))
+          top_i = static_cast<int>(m_Top_dims[0]) - 1;
+        if (top_j >= static_cast<int>(m_Top_dims[1]))
+          top_j = static_cast<int>(m_Top_dims[1]) - 1;
 
           top = -m_Top_surface[top_i*m_Top_dims[1] + top_j];
 
@@ -152,35 +166,43 @@ void MaterialGMG::set_material_properties(std::vector<Sarray> & rho,
                 if (z < intf)
                   z = intf;
 
-                // i0, j0, k0 are the coordiates in GMG block
-                i0 = static_cast<int>( floor(gmg_x/m_hh[gr]) );
-                j0 = static_cast<int>( floor(gmg_y/m_hh[gr]) );
-                int k0 = static_cast<int>( floor((z-intf)/m_hv[gr]) );
+          // i0, j0, k0 are the coordiates in GMG block
+          const double block_xmax = (m_ni[gr] - 1) * m_hh[gr];
+          const double block_ymax = (m_nj[gr] - 1) * m_hh[gr];
+          const double block_tol =
+              std::max(1e-6 * m_hh[gr],
+                       1e-10 * std::max(block_xmax, block_ymax));
+          double block_x = gmg_clamp_coordinate(gmg_x, 0.0, block_xmax,
+                                                block_tol,
+                                                outside_gmg_horizontal);
+          double block_y = gmg_clamp_coordinate(gmg_y, 0.0, block_ymax,
+                                                block_tol,
+                                                outside_gmg_horizontal);
+          i0 = static_cast<int>(floor(block_x / m_hh[gr]));
+          j0 = static_cast<int>(floor(block_y / m_hh[gr]));
+          int k0 = static_cast<int>(floor((z - intf) / m_hv[gr]));
 
                 // (x, y, z) is the coordinate of current grid point
 		if( m_Zmin <= z && z <= m_Zmax) {
 
 		   material++;
 
-                   // Extend the material value if simulation grid is larger than material grid
-                   if (i0 >= m_ni[gr] - 1)
-                       i0 = m_ni[gr] - 2;
-                   if (i0 < 0)
-                       i0 = 0;
-                   if (j0 >= m_nj[gr] - 1)
-                       j0 = m_nj[gr] - 2;
-                   if (j0 < 0)
-                       j0 = 0;
-                   if (k0 >= m_nk[gr] - 1)
-                       k0 = m_nk[gr] - 2;
-                   if (k0 < 0)
-                       k0 = 0;
+            // Keep the interpolation stencil inside the GMG block after
+            // tolerance-limited edge clamping. Horizontal coordinates outside
+            // the GMG extent beyond tolerance are reported as input errors.
+            if (i0 >= m_ni[gr] - 1) i0 = m_ni[gr] - 2;
+            if (i0 < 0) i0 = 0;
+            if (j0 >= m_nj[gr] - 1) j0 = m_nj[gr] - 2;
+            if (j0 < 0) j0 = 0;
+            if (k0 >= m_nk[gr] - 1) k0 = m_nk[gr] - 2;
+            if (k0 < 0) k0 = 0;
 
-		   // Use bilinear interpolation always:
-        	   // Bias stencil near the boundary, need to communicate arrays afterwards.
-                   float_sw4 wghx = (gmg_x - i0*m_hh[gr]) / m_hh[gr];
-                   float_sw4 wghy = (gmg_y - j0*m_hh[gr]) / m_hh[gr];
-                   float_sw4 wghz = (z - intf - k0*m_hv[gr]) / m_hv[gr];
+            // Use bilinear interpolation always:
+            // Bias stencil near the boundary, need to communicate arrays
+            // afterwards.
+            float_sw4 wghx = (block_x - i0 * m_hh[gr]) / m_hh[gr];
+            float_sw4 wghy = (block_y - j0 * m_hh[gr]) / m_hh[gr];
+            float_sw4 wghz = (z - intf - k0 * m_hv[gr]) / m_hv[gr];
 
                    /* if (x == 80000 && y == 9000) { */
                    /*     printf("g=%d, ijk: %d %d %d, lalo: %f %f, converted gmg xyz: %f %f %f, intf %f, gr %d, ijk %d %d %d, mat %f %f %f\n", */ 
@@ -268,10 +290,33 @@ void MaterialGMG::set_material_properties(std::vector<Sarray> & rho,
         } // End for k
    } // end for g...
 
-   free(m_CRS);
-   for (int i = 0; i < m_npatches; i++)
-     delete [] m_Material[i];
-   delete [] m_Top_surface;
+  double gmg_x_min_global, gmg_x_max_global, gmg_y_min_global,
+      gmg_y_max_global;
+  long long outside_gmg_horizontal_global;
+  MPI_Allreduce(&gmg_x_min, &gmg_x_min_global, 1, MPI_DOUBLE, MPI_MIN,
+                mEW->m_1d_communicator);
+  MPI_Allreduce(&gmg_x_max, &gmg_x_max_global, 1, MPI_DOUBLE, MPI_MAX,
+                mEW->m_1d_communicator);
+  MPI_Allreduce(&gmg_y_min, &gmg_y_min_global, 1, MPI_DOUBLE, MPI_MIN,
+                mEW->m_1d_communicator);
+  MPI_Allreduce(&gmg_y_max, &gmg_y_max_global, 1, MPI_DOUBLE, MPI_MAX,
+                mEW->m_1d_communicator);
+  MPI_Allreduce(&outside_gmg_horizontal, &outside_gmg_horizontal_global, 1,
+                MPI_LONG_LONG, MPI_SUM, mEW->m_1d_communicator);
+  if (mEW->getRank() == 0)
+    printf("GMG material projected bounds: x=[%e,%e], y=[%e,%e]\n",
+           gmg_x_min_global, gmg_x_max_global, gmg_y_min_global,
+           gmg_y_max_global);
+  CHECK_INPUT(
+      outside_gmg_horizontal_global == 0,
+      "ERROR: GMG material projection maps "
+          << outside_gmg_horizontal_global
+          << " grid coordinates outside the material extent. "
+          << "Check CRS, axis order, origin, and azimuth.");
+
+  free(m_CRS);
+  for (int i = 0; i < m_npatches; i++) delete[] m_Material[i];
+  delete[] m_Top_surface;
 
    mEW->communicate_arrays( rho );
    mEW->communicate_arrays( cs );
@@ -358,8 +403,6 @@ static char* read_hdf5_attr_str(hid_t loc, const char *name)
   /* fprintf(stderr, "Read data: [%s]\n", data); */
   return data;
 }
-#include "GMGHDF5Helpers.h"
-
 static std::string trim_hdf5_string(const char* data, size_t len)
 {
   size_t end = len;
@@ -636,14 +679,19 @@ void MaterialGMG::read_gmg()
       if (mEW->getVerbosity() >= 2) {
         printf("  GMG header block #%i (%s)\n", p, blocks[p].name.c_str());
         printf("    ztop=%f, hh=%f, hv=%f\n", m_ztop[p], m_hh[p], m_hv[p]);
-        printf("    nc=%lld, ni=%lld, nj=%lld, nk=%lld\n", dims[3], dims[0], dims[1], dims[2]);
+        printf("    nc=%llu, ni=%llu, nj=%llu, nk=%llu\n",
+               static_cast<unsigned long long>(dims[3]),
+               static_cast<unsigned long long>(dims[0]),
+               static_cast<unsigned long long>(dims[1]),
+               static_cast<unsigned long long>(dims[2]));
       }
     } // End for each patch
 
     topo_grp = H5Gopen(file_id, "surfaces", H5P_DEFAULT);
     ASSERT(topo_grp >= 0);
 
-    dataset_id = open_gmg_surface_dataset(topo_grp, &surface_name);
+    dataset_id = open_gmg_surface_dataset(topo_grp, &surface_name,
+                                          GMG_SURFACE_MODEL_TOP);
     CHECK_INPUT(dataset_id >= 0,
                 "ERROR: GMG /surfaces must contain one of: top_surface, topography_bathymetry");
 

--- a/src/MaterialGMG.C
+++ b/src/MaterialGMG.C
@@ -33,6 +33,8 @@
 
 #include "Require.h"
 
+#include <algorithm>
+#include <cctype>
 #include <cstring>
 #include <stdlib.h>
 #include <unistd.h>
@@ -57,7 +59,12 @@ MaterialGMG::MaterialGMG( EW* a_ew, const string a_file, const string a_director
    mEW(a_ew),
    m_model_file(a_file),
    m_model_dir(a_directory),
-   m_use_attenuation(false)
+   m_use_attenuation(false),
+   m_idx_rho(0),
+   m_idx_vp(1),
+   m_idx_vs(2),
+   m_idx_qp(3),
+   m_idx_qs(4)
 {
    mCoversAllPoints = false;
    // Check that the depths make sense
@@ -110,10 +117,15 @@ void MaterialGMG::set_material_properties(std::vector<Sarray> & rho,
           gmg_y = xRel*sinAz + yRel*cosAz;
 
 
-          i0 = static_cast<int>( floor(gmg_x/m_hh[0]) );
-          j0 = static_cast<int>( floor(gmg_y/m_hh[0]) );
+          const int top_i = static_cast<int>(floor(gmg_x/m_Top_hx));
+          const int top_j = static_cast<int>(floor(gmg_y/m_Top_hy));
+          if (top_i < 0 || top_i >= static_cast<int>(m_Top_dims[0]) ||
+              top_j < 0 || top_j >= static_cast<int>(m_Top_dims[1])) {
+            outside += static_cast<size_t>(mEW->m_kEnd[g] - mEW->m_kStart[g] + 1);
+            continue;
+          }
 
-          top = -m_Top_surface[i0*m_Top_dims[1] + j0];
+          top = -m_Top_surface[top_i*m_Top_dims[1] + top_j];
 
           for (int k = mEW->m_kStart[g]; k <= mEW->m_kEnd[g]; ++k) {
 		float_sw4 z;
@@ -194,10 +206,10 @@ void MaterialGMG::set_material_properties(std::vector<Sarray> & rho,
                        if (wghz < 0) wghz = 0;
                    }
 
-                   rho[g](i, j, k) = (1-wghz)*( (1-wghy)*((1-wghx)*mat(gr,0,i0,j0,k0) + wghx*mat(gr,0,i0+1,j0,k0)) +
-                                                wghy*( (1-wghx)*mat(gr,0,i0,j0+1,k0) + wghx*mat(gr,0,i0+1,j0+1,k0)) ) + 
-                                     wghz*( (1-wghy)*((1-wghx)*mat(gr,0,i0,j0,k0+1) + wghx*mat(gr,0,i0+1,j0,k0+1) ) +
-                                             wghy*((1-wghx)*mat(gr,0,i0,j0+1,k0+1)+ wghx*mat(gr,0,i0+1,j0+1,k0+1)) );
+                   rho[g](i, j, k) = (1-wghz)*( (1-wghy)*((1-wghx)*mat(gr,m_idx_rho,i0,j0,k0) + wghx*mat(gr,m_idx_rho,i0+1,j0,k0)) +
+                                                wghy*( (1-wghx)*mat(gr,m_idx_rho,i0,j0+1,k0) + wghx*mat(gr,m_idx_rho,i0+1,j0+1,k0)) ) + 
+                                     wghz*( (1-wghy)*((1-wghx)*mat(gr,m_idx_rho,i0,j0,k0+1) + wghx*mat(gr,m_idx_rho,i0+1,j0,k0+1) ) +
+                                             wghy*((1-wghx)*mat(gr,m_idx_rho,i0,j0+1,k0+1)+ wghx*mat(gr,m_idx_rho,i0+1,j0+1,k0+1)) );
 
                    /* if (x == 80000 && y == 9000) { */
                    /*     printf("g=%d, ijk: %d %d %d, lalo: %f %f, converted gmg xyz: %f %f %f, intf %f, gr %d, ijk %d %d %d, mat %f %f %f, rho=%f\n", */ 
@@ -208,20 +220,20 @@ void MaterialGMG::set_material_properties(std::vector<Sarray> & rho,
                    /*   ASSERT(0); */
                    /* } */
 
-                   cp[g](i, j, k) = (1-wghz)*( (1-wghy)*((1-wghx)*mat(gr,1,i0,j0,k0) + wghx*mat(gr,1,i0+1,j0,k0)) +
-                                               wghy*( (1-wghx)*mat(gr,1,i0,j0+1,k0) + wghx*mat(gr,1,i0+1,j0+1,k0)) ) + 
-                                    wghz*( (1-wghy)*((1-wghx)*mat(gr,1,i0,j0,k0+1) + wghx*mat(gr,1,i0+1,j0,k0+1) ) +
-                                            wghy*((1-wghx)*mat(gr,1,i0,j0+1,k0+1)+ wghx*mat(gr,1,i0+1,j0+1,k0+1)) );
+                   cp[g](i, j, k) = (1-wghz)*( (1-wghy)*((1-wghx)*mat(gr,m_idx_vp,i0,j0,k0) + wghx*mat(gr,m_idx_vp,i0+1,j0,k0)) +
+                                               wghy*( (1-wghx)*mat(gr,m_idx_vp,i0,j0+1,k0) + wghx*mat(gr,m_idx_vp,i0+1,j0+1,k0)) ) + 
+                                    wghz*( (1-wghy)*((1-wghx)*mat(gr,m_idx_vp,i0,j0,k0+1) + wghx*mat(gr,m_idx_vp,i0+1,j0,k0+1) ) +
+                                            wghy*((1-wghx)*mat(gr,m_idx_vp,i0,j0+1,k0+1)+ wghx*mat(gr,m_idx_vp,i0+1,j0+1,k0+1)) );
        
                    /* if (cp[g](i,j,k) < 700) { */
                      /* printf("Rank %d, cp[%d](%d, %d, %d)=%.2f\n", mEW->getRank(), g, i, j, k, cp[g](i,j,k)); */
                      /* ASSERT(0); */
                    /* } */
 
-                   cs[g](i, j, k) = (1-wghz)*( (1-wghy)*((1-wghx)*mat(gr,2,i0,j0,k0) + wghx*mat(gr,2,i0+1,j0,k0)) +
-                                               wghy*( (1-wghx)*mat(gr,2,i0,j0+1,k0) + wghx*mat(gr,2,i0+1,j0+1,k0)) ) + 
-                                    wghz*( (1-wghy)*((1-wghx)*mat(gr,2,i0,j0,k0+1) + wghx*mat(gr,2,i0+1,j0,k0+1) ) +
-                                            wghy*((1-wghx)*mat(gr,2,i0,j0+1,k0+1)+ wghx*mat(gr,2,i0+1,j0+1,k0+1)) );
+                   cs[g](i, j, k) = (1-wghz)*( (1-wghy)*((1-wghx)*mat(gr,m_idx_vs,i0,j0,k0) + wghx*mat(gr,m_idx_vs,i0+1,j0,k0)) +
+                                               wghy*( (1-wghx)*mat(gr,m_idx_vs,i0,j0+1,k0) + wghx*mat(gr,m_idx_vs,i0+1,j0+1,k0)) ) + 
+                                    wghz*( (1-wghy)*((1-wghx)*mat(gr,m_idx_vs,i0,j0,k0+1) + wghx*mat(gr,m_idx_vs,i0+1,j0,k0+1) ) +
+                                            wghy*((1-wghx)*mat(gr,m_idx_vs,i0,j0+1,k0+1)+ wghx*mat(gr,m_idx_vs,i0+1,j0+1,k0+1)) );
 
 #ifdef BZ_DEBUG
                    if (cs[g](i,j,k) < 0) {
@@ -231,15 +243,15 @@ void MaterialGMG::set_material_properties(std::vector<Sarray> & rho,
 #endif
 
                    if( use_q ) {
-                      xip[g](i, j, k) = (1-wghz)*( (1-wghy)*((1-wghx)*mat(gr,3,i0,j0,k0) + wghx*mat(gr,3,i0+1,j0,k0)) +
-                                                   wghy*( (1-wghx)*mat(gr,3,i0,j0+1,k0) + wghx*mat(gr,3,i0+1,j0+1,k0)) ) + 
-                                        wghz*( (1-wghy)*((1-wghx)*mat(gr,3,i0,j0,k0+1) + wghx*mat(gr,3,i0+1,j0,k0+1) ) +
-                                                wghy*((1-wghx)*mat(gr,3,i0,j0+1,k0+1)+ wghx*mat(gr,3,i0+1,j0+1,k0+1)) );
+                      xip[g](i, j, k) = (1-wghz)*( (1-wghy)*((1-wghx)*mat(gr,m_idx_qp,i0,j0,k0) + wghx*mat(gr,m_idx_qp,i0+1,j0,k0)) +
+                                                   wghy*( (1-wghx)*mat(gr,m_idx_qp,i0,j0+1,k0) + wghx*mat(gr,m_idx_qp,i0+1,j0+1,k0)) ) + 
+                                        wghz*( (1-wghy)*((1-wghx)*mat(gr,m_idx_qp,i0,j0,k0+1) + wghx*mat(gr,m_idx_qp,i0+1,j0,k0+1) ) +
+                                                wghy*((1-wghx)*mat(gr,m_idx_qp,i0,j0+1,k0+1)+ wghx*mat(gr,m_idx_qp,i0+1,j0+1,k0+1)) );
 
-                      xis[g](i, j, k) = (1-wghz)*( (1-wghy)*((1-wghx)*mat(gr,4,i0,j0,k0) + wghx*mat(gr,4,i0+1,j0,k0)) +
-                                                   wghy*( (1-wghx)*mat(gr,4,i0,j0+1,k0) + wghx*mat(gr,4,i0+1,j0+1,k0)) ) + 
-                                        wghz*( (1-wghy)*((1-wghx)*mat(gr,4,i0,j0,k0+1) + wghx*mat(gr,4,i0+1,j0,k0+1) ) +
-                                                wghy*((1-wghx)*mat(gr,4,i0,j0+1,k0+1)+ wghx*mat(gr,4,i0+1,j0+1,k0+1)) );
+                      xis[g](i, j, k) = (1-wghz)*( (1-wghy)*((1-wghx)*mat(gr,m_idx_qs,i0,j0,k0) + wghx*mat(gr,m_idx_qs,i0+1,j0,k0)) +
+                                                   wghy*( (1-wghx)*mat(gr,m_idx_qs,i0,j0+1,k0) + wghx*mat(gr,m_idx_qs,i0+1,j0+1,k0)) ) + 
+                                        wghz*( (1-wghy)*((1-wghx)*mat(gr,m_idx_qs,i0,j0,k0+1) + wghx*mat(gr,m_idx_qs,i0+1,j0,k0+1) ) +
+                                                wghy*((1-wghx)*mat(gr,m_idx_qs,i0,j0+1,k0+1)+ wghx*mat(gr,m_idx_qs,i0+1,j0+1,k0+1)) );
                    }
 
 		} // End if inside
@@ -340,6 +352,197 @@ static char* read_hdf5_attr_str(hid_t loc, const char *name)
   /* fprintf(stderr, "Read data: [%s]\n", data); */
   return data;
 }
+
+static bool read_hdf5_attr_optional_f64(hid_t loc, const char* name,
+                                        double& data)
+{
+  if (H5Aexists(loc, name) <= 0)
+    return false;
+  read_hdf5_attr(loc, H5T_IEEE_F64LE, name, &data);
+  return true;
+}
+
+static void read_gmg_surface_spacing(hid_t dataset_id, double& hx, double& hy)
+{
+  double h = 0.0;
+  const bool has_h =
+      read_hdf5_attr_optional_f64(dataset_id, "resolution_horiz", h);
+  const bool has_hx =
+      read_hdf5_attr_optional_f64(dataset_id, "x_resolution", hx);
+  const bool has_hy =
+      read_hdf5_attr_optional_f64(dataset_id, "y_resolution", hy);
+
+  CHECK_INPUT(has_h || (has_hx && has_hy),
+              "ERROR: GMG surface dataset must define resolution_horiz or "
+              "both x_resolution and y_resolution");
+
+  if (!has_hx)
+    hx = h;
+  if (!has_hy)
+    hy = h;
+
+  CHECK_INPUT(hx > 0 && hy > 0,
+              "ERROR: GMG surface spacing must be positive, got hx="
+                  << hx << " hy=" << hy);
+}
+
+static hid_t open_gmg_surface_dataset(hid_t group_id,
+                                      const char** surface_name)
+{
+  const char* candidates[] = {"top_surface", "topography_bathymetry"};
+  const int ncandidates = sizeof(candidates) / sizeof(candidates[0]);
+
+  for (int i = 0; i < ncandidates; i++) {
+    if (H5Lexists(group_id, candidates[i], H5P_DEFAULT) > 0) {
+      if (surface_name)
+        *surface_name = candidates[i];
+      return H5Dopen(group_id, candidates[i], H5P_DEFAULT);
+    }
+  }
+
+  return -1;
+}
+
+static std::string trim_hdf5_string(const char* data, size_t len)
+{
+  size_t end = len;
+  while (end > 0 && (data[end-1] == '\0' ||
+                     isspace(static_cast<unsigned char>(data[end-1]))))
+    --end;
+  return std::string(data, end);
+}
+
+static std::string normalize_gmg_component_name(const std::string& name)
+{
+  std::string normalized;
+  normalized.reserve(name.size());
+  for (size_t i = 0; i < name.size(); i++) {
+    unsigned char ch = static_cast<unsigned char>(name[i]);
+    if (isalnum(ch))
+      normalized.push_back(static_cast<char>(tolower(ch)));
+  }
+  return normalized;
+}
+
+static std::vector<std::string> read_hdf5_attr_str_array_optional(hid_t loc,
+                                                                  const char* name)
+{
+  std::vector<std::string> values;
+  if (H5Aexists(loc, name) <= 0)
+    return values;
+
+  hid_t attr_id = H5Aopen(loc, name, H5P_DEFAULT);
+  ASSERT(attr_id >= 0);
+  hid_t dtype = H5Aget_type(attr_id);
+  hid_t aspace = H5Aget_space(attr_id);
+  ASSERT(dtype >= 0);
+  ASSERT(aspace >= 0);
+
+  CHECK_INPUT(H5Tget_class(dtype) == H5T_STRING,
+              "ERROR: GMG attribute '" << name << "' must be a string array");
+
+  hssize_t nvals = H5Sget_simple_extent_npoints(aspace);
+  CHECK_INPUT(nvals >= 0,
+              "ERROR: invalid size for GMG attribute '" << name << "'");
+  values.reserve(static_cast<size_t>(nvals));
+
+  if (H5Tis_variable_str(dtype)) {
+    std::vector<char*> raw_values(static_cast<size_t>(nvals), NULL);
+    int ierr = H5Aread(attr_id, dtype, raw_values.data());
+    ASSERT(ierr >= 0);
+    for (hssize_t i = 0; i < nvals; i++)
+      values.push_back(raw_values[i] ? raw_values[i] : "");
+#if H5_VERSION_GE(1, 12, 0)
+    H5Treclaim(dtype, aspace, H5P_DEFAULT, raw_values.data());
+#else
+    H5Dvlen_reclaim(dtype, aspace, H5P_DEFAULT, raw_values.data());
+#endif
+  }
+  else {
+    const size_t elem_size = H5Tget_size(dtype);
+    std::vector<char> raw_values(static_cast<size_t>(nvals) * elem_size);
+    int ierr = H5Aread(attr_id, dtype, raw_values.data());
+    ASSERT(ierr >= 0);
+    for (hssize_t i = 0; i < nvals; i++)
+      values.push_back(trim_hdf5_string(&raw_values[i*elem_size], elem_size));
+  }
+
+  H5Sclose(aspace);
+  H5Tclose(dtype);
+  H5Aclose(attr_id);
+
+  return values;
+}
+
+static void resolve_gmg_component_indices(const std::vector<std::string>& components,
+                                          bool use_attenuation, int& idx_rho,
+                                          int& idx_vp, int& idx_vs, int& idx_qp,
+                                          int& idx_qs)
+{
+  idx_rho = 0;
+  idx_vp = 1;
+  idx_vs = 2;
+  idx_qp = 3;
+  idx_qs = 4;
+
+  if (components.empty())
+    return;
+
+  idx_rho = idx_vp = idx_vs = idx_qp = idx_qs = -1;
+  for (size_t i = 0; i < components.size(); i++) {
+    const std::string key = normalize_gmg_component_name(components[i]);
+    if (key == "density" || key == "rho")
+      idx_rho = static_cast<int>(i);
+    else if (key == "vp" || key == "pvelocity")
+      idx_vp = static_cast<int>(i);
+    else if (key == "vs" || key == "svelocity")
+      idx_vs = static_cast<int>(i);
+    else if (key == "qp")
+      idx_qp = static_cast<int>(i);
+    else if (key == "qs")
+      idx_qs = static_cast<int>(i);
+  }
+
+  CHECK_INPUT(idx_rho >= 0 && idx_vp >= 0 && idx_vs >= 0,
+              "ERROR: GMG data_values must define density/rho, Vp, and Vs");
+  if (use_attenuation)
+    CHECK_INPUT(idx_qp >= 0 && idx_qs >= 0,
+                "ERROR: GMG attenuation requires Qp and Qs in data_values");
+}
+
+struct GmgBlockInfo {
+  std::string name;
+  double ztop;
+  double hh;
+  double hv;
+  hsize_t dims[4];
+};
+
+static herr_t collect_gmg_block_names(hid_t loc_id, const char* name,
+                                      const H5L_info_t* /*info*/,
+                                      void* operator_data)
+{
+#if H5_VERSION_GE(1, 12, 0)
+  H5O_info1_t object_info;
+#else
+  H5O_info_t object_info;
+#endif
+  std::vector<std::string>* block_names =
+      static_cast<std::vector<std::string>*>(operator_data);
+
+  ASSERT(operator_data != NULL);
+
+#if H5_VERSION_GE(1, 12, 0)
+  H5Oget_info_by_name1(loc_id, name, &object_info, H5P_DEFAULT);
+#else
+  H5Oget_info_by_name(loc_id, name, &object_info, H5P_DEFAULT);
+#endif
+
+  if (object_info.type == H5O_TYPE_DATASET)
+    block_names->push_back(name);
+
+  return 0;
+}
 #endif
 
 //-----------------------------------------------------------------------
@@ -354,27 +557,13 @@ void MaterialGMG::read_gmg()
   hid_t file_id, dataset_id, group_id, filespace_id, topo_grp;
   double alpha;
   herr_t ierr;
-  hsize_t dims[4];
-  char grid_name[128];
-  int str_len, hv[5];
+  hsize_t dims[4], top_dims[3];
+  const char* surface_name = NULL;
+  int str_len = 0, top_rank = 0;
   string fname = m_model_dir + "/" + m_model_file;
-
-  // Fixed for GMG grids
-  m_npatches = 4;
-
-  m_hv.resize(m_npatches);
-  m_hh.resize(m_npatches);
-  m_ni.resize(m_npatches);
-  m_nj.resize(m_npatches);
-  m_nk.resize(m_npatches);
-  m_nc.resize(m_npatches);
-  m_ztop.resize(m_npatches);
-  m_Material.resize(m_npatches);
-
-  hv[0] = 25;
-  hv[1] = 50;
-  hv[2] = 125;
-  hv[3] = 250;
+  std::vector<GmgBlockInfo> blocks;
+  std::vector<std::string> components;
+  m_npatches = 0;
 
   if (mEW->getRank() == 0) {
     file_id = H5Fopen(fname.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
@@ -392,43 +581,90 @@ void MaterialGMG::read_gmg()
     fprintf(stderr, "origin: %f %f, az %f, dim_z %f\n", m_Origin_x, m_Origin_y, m_Yaz, m_Zmax);
 #endif
 
-    // Origin_x is not correctly read sometimes
-    if (m_Origin_x < 1) {
-      m_Origin_x = 99286.2;
-      if (mEW->getRank() == 0)
-        printf("GMG origin_x read invalid value, correct to 99286.2 \n");
-    }
-
     m_CRS = read_hdf5_attr_str(file_id, "crs");
     str_len = (int)(strlen(m_CRS)+1);
+    components = read_hdf5_attr_str_array_optional(file_id, "data_values");
+    resolve_gmg_component_indices(components, m_use_attenuation, m_idx_rho,
+                                  m_idx_vp, m_idx_vs, m_idx_qp, m_idx_qs);
 
     group_id = H5Gopen(file_id, "blocks", H5P_DEFAULT);
     ASSERT(group_id >= 0);
 
+    std::vector<std::string> block_names;
+    ierr = H5Literate(group_id, H5_INDEX_NAME, H5_ITER_NATIVE, NULL,
+                      collect_gmg_block_names, &block_names);
+    ASSERT(ierr >= 0);
+
+    m_npatches = (int)block_names.size();
+    CHECK_INPUT(m_npatches > 0,
+                "ERROR: GMG file contains no datasets in /blocks");
+
+    blocks.resize(m_npatches);
+
     for( int p = 0 ; p < m_npatches ; p++ ) {
-      sprintf(grid_name, "vres%dm", hv[p]);
-      dataset_id = H5Dopen(group_id, grid_name, H5P_DEFAULT);
+      blocks[p].name = block_names[p];
+      dataset_id = H5Dopen(group_id, block_names[p].c_str(), H5P_DEFAULT);
       ASSERT(dataset_id >= 0);
 
       filespace_id = H5Dget_space(dataset_id);
       H5Sget_simple_extent_dims(filespace_id, dims, NULL);
+      H5Sclose(filespace_id);
 
 #ifdef BZ_DEBUG
       fprintf(stderr, "Rank %d, p=%d dims: %ld %ld %ld %ld\n", mEW->getRank(), p, dims[0], dims[1], dims[2], dims[3]);
 #endif
 
-      m_ni[p] = (int)dims[0];
-      m_nj[p] = (int)dims[1];
-      m_nk[p] = (int)dims[2];
-      m_nc[p] = (int)dims[3];
+      for (int d = 0; d < 4; d++)
+        blocks[p].dims[d] = dims[d];
 
-      read_hdf5_attr(dataset_id, H5T_IEEE_F64LE, "z_top",            &m_ztop[p]);
-      read_hdf5_attr(dataset_id, H5T_IEEE_F64LE, "resolution_horiz", &m_hh[p]);
-      read_hdf5_attr(dataset_id, H5T_IEEE_F64LE, "resolution_vert",  &m_hv[p]);
+      read_hdf5_attr(dataset_id, H5T_IEEE_F64LE, "z_top",            &blocks[p].ztop);
+      read_hdf5_attr(dataset_id, H5T_IEEE_F64LE, "resolution_horiz", &blocks[p].hh);
+      read_hdf5_attr(dataset_id, H5T_IEEE_F64LE, "resolution_vert",  &blocks[p].hv);
 
-      // Make assumption is correct with the data
-      ASSERT(hv[p] == (int)m_hv[p]);
-      ASSERT(dims[3] == 7);
+      H5Dclose(dataset_id);
+    }
+
+    std::sort(blocks.begin(), blocks.end(),
+              [](const GmgBlockInfo& lhs, const GmgBlockInfo& rhs) {
+                if (lhs.ztop != rhs.ztop)
+                  return lhs.ztop > rhs.ztop;
+                return lhs.hv < rhs.hv;
+              });
+
+    m_hv.resize(m_npatches);
+    m_hh.resize(m_npatches);
+    m_ni.resize(m_npatches);
+    m_nj.resize(m_npatches);
+    m_nk.resize(m_npatches);
+    m_nc.resize(m_npatches);
+    m_ztop.resize(m_npatches);
+    m_Material.resize(m_npatches);
+
+    for( int p = 0 ; p < m_npatches ; p++ ) {
+      dataset_id = H5Dopen(group_id, blocks[p].name.c_str(), H5P_DEFAULT);
+      ASSERT(dataset_id >= 0);
+
+      filespace_id = H5Dget_space(dataset_id);
+      H5Sget_simple_extent_dims(filespace_id, dims, NULL);
+
+      m_ni[p] = (int)blocks[p].dims[0];
+      m_nj[p] = (int)blocks[p].dims[1];
+      m_nk[p] = (int)blocks[p].dims[2];
+      m_nc[p] = (int)blocks[p].dims[3];
+      m_ztop[p] = blocks[p].ztop;
+      m_hh[p] = blocks[p].hh;
+      m_hv[p] = blocks[p].hv;
+
+      int max_required_component =
+          std::max(m_idx_rho, std::max(m_idx_vp, m_idx_vs));
+      if (m_use_attenuation)
+        max_required_component =
+            std::max(max_required_component, std::max(m_idx_qp, m_idx_qs));
+      CHECK_INPUT(dims[3] > static_cast<hsize_t>(max_required_component),
+                  "ERROR: GMG block " << blocks[p].name
+                                     << " does not contain required material components; nc="
+                                     << dims[3] << " max required index="
+                                     << max_required_component);
 
       m_Material[p] = new float[dims[0]*dims[1]*dims[2]*dims[3]]();
       ierr = H5Dread(dataset_id, H5T_IEEE_F32LE, H5S_ALL, filespace_id, H5P_DEFAULT, &m_Material[p][0]);
@@ -438,8 +674,8 @@ void MaterialGMG::read_gmg()
       H5Dclose(dataset_id);
 
       if (mEW->getVerbosity() >= 2) {
-        printf("  GMG header block #%i\n", p);
-        printf("    hh=%f, hv=%f\n", m_hh[p], m_hv[p]);
+        printf("  GMG header block #%i (%s)\n", p, blocks[p].name.c_str());
+        printf("    ztop=%f, hh=%f, hv=%f\n", m_ztop[p], m_hh[p], m_hv[p]);
         printf("    nc=%lld, ni=%lld, nj=%lld, nk=%lld\n", dims[3], dims[0], dims[1], dims[2]);
       }
     } // End for each patch
@@ -447,11 +683,23 @@ void MaterialGMG::read_gmg()
     topo_grp = H5Gopen(file_id, "surfaces", H5P_DEFAULT);
     ASSERT(topo_grp >= 0);
 
-    dataset_id = H5Dopen(topo_grp, "top_surface", H5P_DEFAULT);
-    ASSERT(dataset_id >= 0);
+    dataset_id = open_gmg_surface_dataset(topo_grp, &surface_name);
+    CHECK_INPUT(dataset_id >= 0,
+                "ERROR: GMG /surfaces must contain one of: top_surface, topography_bathymetry");
 
     filespace_id = H5Dget_space(dataset_id);
-    H5Sget_simple_extent_dims(filespace_id, &m_Top_dims[0], NULL);
+    top_rank = H5Sget_simple_extent_ndims(filespace_id);
+    CHECK_INPUT(top_rank == 2 || top_rank == 3,
+                "ERROR: GMG top_surface must be rank-2 or rank-3, got "
+                    << top_rank);
+    H5Sget_simple_extent_dims(filespace_id, top_dims, NULL);
+    m_Top_dims[0] = top_dims[0];
+    m_Top_dims[1] = top_dims[1];
+    read_gmg_surface_spacing(dataset_id, m_Top_hx, m_Top_hy);
+    if (top_rank == 3)
+      CHECK_INPUT(top_dims[2] == 1,
+                  "ERROR: GMG top_surface third dimension must be 1, got "
+                      << top_dims[2]);
 
 #ifdef BZ_DEBUG
     fprintf(stderr, "Top dims: %ld %ld\n", m_Top_dims[0], m_Top_dims[1]);
@@ -477,6 +725,17 @@ void MaterialGMG::read_gmg()
 
   } // End rank==0
 
+  MPI_Bcast(&m_npatches, 1, MPI_INT, 0, mEW->m_1d_communicator);
+
+  m_hv.resize(m_npatches);
+  m_hh.resize(m_npatches);
+  m_ni.resize(m_npatches);
+  m_nj.resize(m_npatches);
+  m_nk.resize(m_npatches);
+  m_nc.resize(m_npatches);
+  m_ztop.resize(m_npatches);
+  m_Material.resize(m_npatches);
+
   MPI_Barrier(mEW->m_1d_communicator);
 
   MPI_Bcast(&m_Origin_x, 1,          MPI_DOUBLE,    0, mEW->m_1d_communicator);
@@ -484,6 +743,13 @@ void MaterialGMG::read_gmg()
   MPI_Bcast(&m_Yaz,      1,          MPI_DOUBLE,    0, mEW->m_1d_communicator);
   MPI_Bcast(&m_Zmax,     1,          MPI_DOUBLE,    0, mEW->m_1d_communicator);
   MPI_Bcast(&m_Zmin,     1,          MPI_DOUBLE,    0, mEW->m_1d_communicator);
+  MPI_Bcast(&m_Top_hx,   1,          MPI_DOUBLE,    0, mEW->m_1d_communicator);
+  MPI_Bcast(&m_Top_hy,   1,          MPI_DOUBLE,    0, mEW->m_1d_communicator);
+  MPI_Bcast(&m_idx_rho,  1,          MPI_INT,       0, mEW->m_1d_communicator);
+  MPI_Bcast(&m_idx_vp,   1,          MPI_INT,       0, mEW->m_1d_communicator);
+  MPI_Bcast(&m_idx_vs,   1,          MPI_INT,       0, mEW->m_1d_communicator);
+  MPI_Bcast(&m_idx_qp,   1,          MPI_INT,       0, mEW->m_1d_communicator);
+  MPI_Bcast(&m_idx_qs,   1,          MPI_INT,       0, mEW->m_1d_communicator);
   MPI_Bcast(&m_hv[0],    m_npatches, MPI_DOUBLE,    0, mEW->m_1d_communicator);
   MPI_Bcast(&m_hh[0],    m_npatches, MPI_DOUBLE,    0, mEW->m_1d_communicator);
   MPI_Bcast(&m_ni[0],    m_npatches, MPI_INT,       0, mEW->m_1d_communicator);
@@ -497,7 +763,7 @@ void MaterialGMG::read_gmg()
 
   if (mEW->getRank() != 0) {
     /* fprintf(stderr, "Rank %d, strlen: %d, topo dims: %ld %ld\n", mEW->getRank(), str_len, m_Top_dims[0], m_Top_dims[1]); */
-    m_CRS = new char[str_len]();
+    m_CRS = (char*)malloc(str_len*sizeof(char));
     m_Top_surface = new float[m_Top_dims[0]*m_Top_dims[1]];
     for (int p = 0; p < m_npatches; p++) {
       m_Material[p] = new float[m_ni[p]*m_nj[p]*m_nk[p]*m_nc[p]]();
@@ -511,9 +777,13 @@ void MaterialGMG::read_gmg()
   for (int p = 0; p < m_npatches; p++)
     MPI_Bcast(m_Material[p], m_ni[p]*m_nj[p]*m_nk[p]*m_nc[p], MPI_FLOAT, 0, mEW->m_1d_communicator);
 
-  ASSERT(m_Origin_x > 0);
-  ASSERT(m_Origin_y > 0);
-  ASSERT(m_Yaz > 0);
+  CHECK_INPUT(m_Origin_x > 0 && m_Origin_y > 0,
+              "ERROR: invalid GMG origin values origin_x=" << m_Origin_x
+              << " origin_y=" << m_Origin_y);
+  CHECK_INPUT(m_Yaz > 0, "ERROR: invalid GMG y_azimuth " << m_Yaz);
+  CHECK_INPUT(m_Top_hx > 0 && m_Top_hy > 0,
+              "ERROR: invalid GMG surface spacing hx=" << m_Top_hx
+              << " hy=" << m_Top_hy);
 
   alpha = m_Yaz - 180.0;
   CHECK_INPUT( fabs(alpha-mEW->getGridAzimuth()) < 1e-6, "ERROR: gmg azimuth must be equal "
@@ -523,6 +793,10 @@ void MaterialGMG::read_gmg()
   if (mEW->getRank()==0 && mEW->getVerbosity() >= 2) {
     printf("  GMG header: \n");
     printf("    y_azimuth=%e, origin_x=%f, origin_y=%f\n", m_Yaz, m_Origin_x, m_Origin_y);
+    printf("    surface=%s, hx=%f, hy=%f\n",
+           surface_name ? surface_name : "broadcast", m_Top_hx, m_Top_hy);
+    printf("    components: rho=%d vp=%d vs=%d qp=%d qs=%d\n", m_idx_rho,
+           m_idx_vp, m_idx_vs, m_idx_qp, m_idx_qs);
     printf("    nblocks=%d\n", m_npatches);
 #ifdef BZ_DEBUG
     fprintf(stderr, "Rank %d, Done reading GMG data!\n", mEW->getRank());
@@ -558,12 +832,11 @@ void MaterialGMG::fill_in_fluids()
        for( int i=0; i < m_ni[p] ; i++ ) {
           for( int j=0; j < m_nj[p] ; j++ ) {
              int k0 = 0;
-             // Vs is 2 in GMG model
-             while( mat(p,2,i,j,k0) < 0 && k0 < m_nk[p] - 1 )
+             while( mat(p,m_idx_vs,i,j,k0) < 0 && k0 < m_nk[p] - 1 )
                 k0++;
 
              // consider the case where the top block is all water. Then k0 = m_nk-1 and mat(Vs) <0
-             if (k0 == m_nk[p]-1 && mat(p,2,i,j,k0) < 0) {
+             if (k0 == m_nk[p]-1 && mat(p,m_idx_vs,i,j,k0) < 0) {
                 // get value from block p+1
                 if (p<m_npatches-1) {
                    int pd=p+1, id, jd, kd; // index of donor block
@@ -589,12 +862,12 @@ void MaterialGMG::fill_in_fluids()
                    /* fprintf(stderr, "p=%d, ijk: %d %d %d, go to next block for valid value, rho=%f\n", p, i, j, k0, mat(pd,0,id,jd,kd)); */
 
                    // get values from block 'pd'
-                   mat_assign(p,0,i,j,k0, mat(pd,0,id,jd,kd));
-                   mat_assign(p,1,i,j,k0, mat(pd,1,id,jd,kd));
-                   mat_assign(p,2,i,j,k0, mat(pd,2,id,jd,kd));
+                   mat_assign(p,m_idx_rho,i,j,k0, mat(pd,m_idx_rho,id,jd,kd));
+                   mat_assign(p,m_idx_vp,i,j,k0, mat(pd,m_idx_vp,id,jd,kd));
+                   mat_assign(p,m_idx_vs,i,j,k0, mat(pd,m_idx_vs,id,jd,kd));
                    if (m_use_attenuation) {
-                     mat_assign(p,3,i,j,k0, mat(pd,3,id,jd,kd));
-                     mat_assign(p,4,i,j,k0, mat(pd,4,id,jd,kd));
+                     mat_assign(p,m_idx_qp,i,j,k0, mat(pd,m_idx_qp,id,jd,kd));
+                     mat_assign(p,m_idx_qs,i,j,k0, mat(pd,m_idx_qs,id,jd,kd));
                    }
                 }
                 else {
@@ -610,12 +883,12 @@ void MaterialGMG::fill_in_fluids()
              /* } */
 
              for( int k=0 ; k < k0 ; k++ ) {
-                mat_assign(p,0,i,j,k, mat(p,0,i,j,k0));
-                mat_assign(p,1,i,j,k, mat(p,1,i,j,k0));
-                mat_assign(p,2,i,j,k, mat(p,2,i,j,k0));
+                mat_assign(p,m_idx_rho,i,j,k, mat(p,m_idx_rho,i,j,k0));
+                mat_assign(p,m_idx_vp,i,j,k, mat(p,m_idx_vp,i,j,k0));
+                mat_assign(p,m_idx_vs,i,j,k, mat(p,m_idx_vs,i,j,k0));
                 if( m_use_attenuation ) {
-                   mat_assign(p,3,i,j,k, mat(p,3,i,j,k0));
-                   mat_assign(p,4,i,j,k, mat(p,4,i,j,k0));
+                   mat_assign(p,m_idx_qp,i,j,k, mat(p,m_idx_qp,i,j,k0));
+                   mat_assign(p,m_idx_qs,i,j,k, mat(p,m_idx_qs,i,j,k0));
                 }
              } // End for k
 
@@ -634,27 +907,32 @@ void MaterialGMG::material_check( bool water )
       for( int i=0 ; i< m_ni[p] ; i++ )
 	 for( int j=0 ; j< m_nj[p] ; j++ )
             for( int k=0 ; k< m_nk[p] ; k++ ) {
-	       if( water || mat(p,2,i,j,k) > 0 )
+	       if( water || mat(p,m_idx_vs,i,j,k) > 0 )
 	       {
-		  if( mat(p,0,i,j,k) < rhomin )
-		     rhomin = mat(p,0,i,j,k);
-		  if( mat(p,0,i,j,k) > rhomax )
-		     rhomax = mat(p,0,i,j,k);
-		  if( mat(p,1,i,j,k) < cpmin )
-		     cpmin = mat(p,1,i,j,k);
-		  if( mat(p,1,i,j,k) > cpmax )
-		     cpmax = mat(p,1,i,j,k);
-		  if( mat(p,2,i,j,k) < csmin )
-		     csmin = mat(p,2,i,j,k);
-		  if( mat(p,2,i,j,k) > csmax )
-		     csmax = mat(p,2,i,j,k);
-		  double crat = mat(p,1,i,j,k)/mat(p,2,i,j,k);
+		  if( mat(p,m_idx_rho,i,j,k) < rhomin )
+		     rhomin = mat(p,m_idx_rho,i,j,k);
+		  if( mat(p,m_idx_rho,i,j,k) > rhomax )
+		     rhomax = mat(p,m_idx_rho,i,j,k);
+		  if( mat(p,m_idx_vp,i,j,k) < cpmin )
+		     cpmin = mat(p,m_idx_vp,i,j,k);
+		  if( mat(p,m_idx_vp,i,j,k) > cpmax )
+		     cpmax = mat(p,m_idx_vp,i,j,k);
+		  if( mat(p,m_idx_vs,i,j,k) < csmin )
+		     csmin = mat(p,m_idx_vs,i,j,k);
+		  if( mat(p,m_idx_vs,i,j,k) > csmax )
+		     csmax = mat(p,m_idx_vs,i,j,k);
+		  double crat = mat(p,m_idx_vp,i,j,k)/mat(p,m_idx_vs,i,j,k);
 		  if( crat < cratmin ) {
 		     cratmin = crat;
 		     if( printsmallcpcs && crat < 1.41 ) {
 			cout << "crat= " << crat << " at " << i << " " <<  j << " " << k << endl;
-			cout << " material is " << mat(p,0,i,j,k) << " " << mat(p,1,i,j,k) << " " 
-			     << mat(p,2,i,j,k) << " " << mat(p,3,i,j,k) << " " << mat(p,4,i,j,k) << endl;
+			cout << " material is " << mat(p,m_idx_rho,i,j,k) << " " << mat(p,m_idx_vp,i,j,k) << " " 
+			     << mat(p,m_idx_vs,i,j,k) << " ";
+                        if (m_idx_qp >= 0)
+			   cout << mat(p,m_idx_qp,i,j,k) << " ";
+                        if (m_idx_qs >= 0)
+			   cout << mat(p,m_idx_qs,i,j,k);
+                        cout << endl;
 		     }
 		  }
 		  if( crat > cratmax )

--- a/src/MaterialGMG.C
+++ b/src/MaterialGMG.C
@@ -352,56 +352,7 @@ static char* read_hdf5_attr_str(hid_t loc, const char *name)
   /* fprintf(stderr, "Read data: [%s]\n", data); */
   return data;
 }
-
-static bool read_hdf5_attr_optional_f64(hid_t loc, const char* name,
-                                        double& data)
-{
-  if (H5Aexists(loc, name) <= 0)
-    return false;
-  read_hdf5_attr(loc, H5T_IEEE_F64LE, name, &data);
-  return true;
-}
-
-static void read_gmg_surface_spacing(hid_t dataset_id, double& hx, double& hy)
-{
-  double h = 0.0;
-  const bool has_h =
-      read_hdf5_attr_optional_f64(dataset_id, "resolution_horiz", h);
-  const bool has_hx =
-      read_hdf5_attr_optional_f64(dataset_id, "x_resolution", hx);
-  const bool has_hy =
-      read_hdf5_attr_optional_f64(dataset_id, "y_resolution", hy);
-
-  CHECK_INPUT(has_h || (has_hx && has_hy),
-              "ERROR: GMG surface dataset must define resolution_horiz or "
-              "both x_resolution and y_resolution");
-
-  if (!has_hx)
-    hx = h;
-  if (!has_hy)
-    hy = h;
-
-  CHECK_INPUT(hx > 0 && hy > 0,
-              "ERROR: GMG surface spacing must be positive, got hx="
-                  << hx << " hy=" << hy);
-}
-
-static hid_t open_gmg_surface_dataset(hid_t group_id,
-                                      const char** surface_name)
-{
-  const char* candidates[] = {"top_surface", "topography_bathymetry"};
-  const int ncandidates = sizeof(candidates) / sizeof(candidates[0]);
-
-  for (int i = 0; i < ncandidates; i++) {
-    if (H5Lexists(group_id, candidates[i], H5P_DEFAULT) > 0) {
-      if (surface_name)
-        *surface_name = candidates[i];
-      return H5Dopen(group_id, candidates[i], H5P_DEFAULT);
-    }
-  }
-
-  return -1;
-}
+#include "GMGHDF5Helpers.h"
 
 static std::string trim_hdf5_string(const char* data, size_t len)
 {
@@ -559,7 +510,7 @@ void MaterialGMG::read_gmg()
   herr_t ierr;
   hsize_t dims[4], top_dims[3];
   const char* surface_name = NULL;
-  int str_len = 0, top_rank = 0;
+  int str_len = 0;
   string fname = m_model_dir + "/" + m_model_file;
   std::vector<GmgBlockInfo> blocks;
   std::vector<std::string> components;
@@ -687,19 +638,12 @@ void MaterialGMG::read_gmg()
     CHECK_INPUT(dataset_id >= 0,
                 "ERROR: GMG /surfaces must contain one of: top_surface, topography_bathymetry");
 
+    read_gmg_surface_dims(dataset_id, top_dims);
     filespace_id = H5Dget_space(dataset_id);
-    top_rank = H5Sget_simple_extent_ndims(filespace_id);
-    CHECK_INPUT(top_rank == 2 || top_rank == 3,
-                "ERROR: GMG top_surface must be rank-2 or rank-3, got "
-                    << top_rank);
-    H5Sget_simple_extent_dims(filespace_id, top_dims, NULL);
+    ASSERT(filespace_id >= 0);
     m_Top_dims[0] = top_dims[0];
     m_Top_dims[1] = top_dims[1];
     read_gmg_surface_spacing(dataset_id, m_Top_hx, m_Top_hy);
-    if (top_rank == 3)
-      CHECK_INPUT(top_dims[2] == 1,
-                  "ERROR: GMG top_surface third dimension must be 1, got "
-                      << top_dims[2]);
 
 #ifdef BZ_DEBUG
     fprintf(stderr, "Top dims: %ld %ld\n", m_Top_dims[0], m_Top_dims[1]);

--- a/src/MaterialGMG.C
+++ b/src/MaterialGMG.C
@@ -478,16 +478,19 @@ static herr_t collect_gmg_block_names(hid_t loc_id, const char* name,
 #else
   H5O_info_t object_info;
 #endif
+  herr_t ierr;
   std::vector<std::string>* block_names =
       static_cast<std::vector<std::string>*>(operator_data);
 
   ASSERT(operator_data != NULL);
 
 #if H5_VERSION_GE(1, 12, 0)
-  H5Oget_info_by_name1(loc_id, name, &object_info, H5P_DEFAULT);
+  ierr = H5Oget_info_by_name1(loc_id, name, &object_info, H5P_DEFAULT);
 #else
-  H5Oget_info_by_name(loc_id, name, &object_info, H5P_DEFAULT);
+  ierr = H5Oget_info_by_name(loc_id, name, &object_info, H5P_DEFAULT);
 #endif
+  if (ierr < 0)
+    return ierr;
 
   if (object_info.type == H5O_TYPE_DATASET)
     block_names->push_back(name);

--- a/src/MaterialGMG.C
+++ b/src/MaterialGMG.C
@@ -117,13 +117,16 @@ void MaterialGMG::set_material_properties(std::vector<Sarray> & rho,
           gmg_y = xRel*sinAz + yRel*cosAz;
 
 
-          const int top_i = static_cast<int>(floor(gmg_x/m_Top_hx));
-          const int top_j = static_cast<int>(floor(gmg_y/m_Top_hy));
-          if (top_i < 0 || top_i >= static_cast<int>(m_Top_dims[0]) ||
-              top_j < 0 || top_j >= static_cast<int>(m_Top_dims[1])) {
-            outside += static_cast<size_t>(mEW->m_kEnd[g] - mEW->m_kStart[g] + 1);
-            continue;
-          }
+          int top_i = static_cast<int>(floor(gmg_x/m_Top_hx));
+          int top_j = static_cast<int>(floor(gmg_y/m_Top_hy));
+          if (top_i < 0)
+            top_i = 0;
+          else if (top_i >= static_cast<int>(m_Top_dims[0]))
+            top_i = static_cast<int>(m_Top_dims[0]) - 1;
+          if (top_j < 0)
+            top_j = 0;
+          else if (top_j >= static_cast<int>(m_Top_dims[1]))
+            top_j = static_cast<int>(m_Top_dims[1]) - 1;
 
           top = -m_Top_surface[top_i*m_Top_dims[1] + top_j];
 
@@ -163,8 +166,12 @@ void MaterialGMG::set_material_properties(std::vector<Sarray> & rho,
                    // Extend the material value if simulation grid is larger than material grid
                    if (i0 >= m_ni[gr] - 1)
                        i0 = m_ni[gr] - 2;
+                   if (i0 < 0)
+                       i0 = 0;
                    if (j0 >= m_nj[gr] - 1)
                        j0 = m_nj[gr] - 2;
+                   if (j0 < 0)
+                       j0 = 0;
                    if (k0 >= m_nk[gr] - 1)
                        k0 = m_nk[gr] - 2;
                    if (k0 < 0)

--- a/src/MaterialGMG.C
+++ b/src/MaterialGMG.C
@@ -107,8 +107,7 @@ void MaterialGMG::set_material_properties(std::vector<Sarray> & rho,
           mEW->computeGeographicCoord(x, y, sw4_lon, sw4_lat);
           /* printf("\ncomputeGeographicCoord: %f %f %f %f\n", x, y, sw4_lon, sw4_lat); */
 
-          // GMG x/y, lat/lon is switched from sw4 CRS
-          mEW->computeCartesianCoordGMG(gmg_y0, gmg_x0, sw4_lon, sw4_lat, m_CRS);
+          mEW->computeCartesianCoordGMG(gmg_x0, gmg_y0, sw4_lon, sw4_lat, m_CRS);
           /* printf("computeCartesianCoordGMG : %f %f %f %f\n", gmg_x0, gmg_y0, sw4_lon, sw4_lat); */
       
           const double xRel = gmg_x0 - m_Origin_x;

--- a/src/MaterialGMG.h
+++ b/src/MaterialGMG.h
@@ -103,6 +103,7 @@ class MaterialGMG : public MaterialData
  
     bool m_use_attenuation;
     int m_npatches;
+    int m_idx_rho, m_idx_vp, m_idx_vs, m_idx_qp, m_idx_qs;
     double m_Origin_x, m_Origin_y, m_Yaz, m_Zmax, m_Zmin;
     char *m_CRS;
 #ifdef USE_HDF5
@@ -110,6 +111,7 @@ class MaterialGMG : public MaterialData
 #else
     size_t m_Top_dims[2];
 #endif
+    double m_Top_hx, m_Top_hy;
     float* m_Top_surface;
     vector<double> m_hv, m_hh, m_ztop;
     vector<int> m_ni, m_nj, m_nk, m_nc;

--- a/src/SfileOutput.C
+++ b/src/SfileOutput.C
@@ -739,6 +739,14 @@ void SfileOutput::write_image(const char *fname, std::vector<Sarray>& a_Z )
     H5Awrite(attr, H5T_NATIVE_DOUBLE, &spacing);
     H5Aclose(attr);
 
+    aname = "Coarsest horizontal grid spacing";
+    double spacing = mEW->mGridSize[0]*stH;
+    attr = H5Acreate(h5_fid, aname, H5T_NATIVE_DOUBLE, attr_space1, H5P_DEFAULT, H5P_DEFAULT);
+    if( attr < 0 )
+      VERIFY2(0, "ERROR: SfileOutput::write_image, error creating " << aname);
+    H5Awrite(attr, H5T_NATIVE_DOUBLE, &spacing);
+    H5Aclose(attr);
+
     aname = "Attenuation";
     int att = mEW->usingAttenuation();
     attr = H5Acreate(h5_fid, aname, H5T_NATIVE_INT, attr_space1, H5P_DEFAULT, H5P_DEFAULT);

--- a/src/SfileOutput.C
+++ b/src/SfileOutput.C
@@ -740,7 +740,7 @@ void SfileOutput::write_image(const char *fname, std::vector<Sarray>& a_Z )
     H5Aclose(attr);
 
     aname = "Coarsest horizontal grid spacing";
-    double spacing = mEW->mGridSize[0]*stH;
+    spacing = mEW->mGridSize[0]*stH;
     attr = H5Acreate(h5_fid, aname, H5T_NATIVE_DOUBLE, attr_space1, H5P_DEFAULT, H5P_DEFAULT);
     if( attr < 0 )
       VERIFY2(0, "ERROR: SfileOutput::write_image, error creating " << aname);

--- a/src/TimeSeries.C
+++ b/src/TimeSeries.C
@@ -4061,7 +4061,8 @@ hid_t TimeSeries::openHDF5File(std::string suffix)
   if (m_hdf5Name.find(".hdf5") == string::npos && m_hdf5Name.find(".h5") == string::npos) 
     filename.append(".hdf5");
 
-  if (*m_fid_ptr >=0 && this->m_ts0Ptr && filename.compare(this->m_ts0Ptr->m_fidName) == 0) {
+  if (*m_fid_ptr > 0 && this->m_ts0Ptr &&
+      filename.compare(this->m_ts0Ptr->m_fidName) == 0) {
     // If file is alread open, no need to open it again
     return *m_fid_ptr;
   }

--- a/src/TimeSeries.C
+++ b/src/TimeSeries.C
@@ -1329,7 +1329,7 @@ write_hdf5_format(int npts, hid_t grp, float *y, float btime, float dt, char *va
 
   if (isLast && ret == 1) {
     m_nptsWritten += count;
-    H5Gflush(grp);
+    // H5Gflush(grp);
   }
 
   if (mDownSample > 1) 

--- a/src/TimeSeries.C
+++ b/src/TimeSeries.C
@@ -4038,7 +4038,7 @@ void TimeSeries::resetHDF5file()
 }
 
 //-----------------------------------------------------------------------
-hid_t TimeSeries::openHDF5File(std::string suffix)
+hid_t TimeSeries::openHDF5File(std::string suffix, bool quiet)
 {
   hid_t fapl;
   bool is_debug = false;
@@ -4083,7 +4083,8 @@ hid_t TimeSeries::openHDF5File(std::string suffix)
 
   *m_fid_ptr = H5Fopen(filename.c_str(),  H5F_ACC_RDWR, fapl);
   if (*m_fid_ptr <= 0) {
-    printf("%s Error opening file [%s]\n", __func__, filename.c_str());
+    if (!quiet)
+      printf("%s Error opening file [%s]\n", __func__, filename.c_str());
     H5Pclose(fapl);
     return 0;
   }

--- a/src/TimeSeries.h
+++ b/src/TimeSeries.h
@@ -161,7 +161,7 @@ hid_t *getFidPtr() {return m_fid_ptr;};
 int   closeHDF5File();
 void  resetHDF5file();
 void  readSACHDF5( EW *ew, string FileName, bool ignore_utc );
-hid_t openHDF5File(std::string suffix);
+hid_t openHDF5File(std::string suffix, bool quiet=false);
 void  write_hdf5_format( int npts, hid_t loc, float *y, float btime, float dt, char *var,
 		       float cmpinc, float cmpaz, bool makeCopy=false, bool isLast=false);
 double getWriteTime() {return m_writeTime;};

--- a/src/parseInputFile.C
+++ b/src/parseInputFile.C
@@ -6263,7 +6263,7 @@ void EW::processRupture(char* buffer, vector<vector<Source*> > & a_GlobalUniqueS
       printf("Number of point sources in data block: %i\n", npts);
 
 // read all point sources
-    int nSources=0, nu1=0, nu2=0, nu3=0;
+    int nSources=0, nu1=0, nu2=0, nu3=0, nskip_zero_slip=0;
     for (int pts=0; pts<npts; pts++) 
     {
       double lon, lat, dep, stk, dip, area, tinit, dt, rake, slip1, slip2, slip3;
@@ -6341,6 +6341,19 @@ void EW::processRupture(char* buffer, vector<vector<Source*> > & a_GlobalUniqueS
         if (proc_zero() && mVerbose >= 2)
         {
            printf("INFO: SRF file: dt*sum(slip_vel)=%e [m], total slip (from header)=%e [m]\n", slip_sum, slip_m);
+        }
+        float_sw4 slip_sum_tol = 1e-12;
+        if( slip_sum > -slip_sum_tol && slip_sum < slip_sum_tol )
+        {
+           nskip_zero_slip++;
+           if( proc_zero() && nskip_zero_slip <= 10 )
+           {
+              printf("WARNING: skipping rupture point #%i because dt*sum(slip_vel)=%e [m], slip1=%e [m]\n",
+                     pts+1, slip_sum, slip_m);
+           }
+           for (int i=1; i<=nt1dim+1; i++)
+              par[i] = 0;
+           slip_sum = 1;
         }
 // scale time series to sum to integrate to one        
 	for (int i=1; i<=nt1dim+1; i++)
@@ -6511,6 +6524,8 @@ void EW::processRupture(char* buffer, vector<vector<Source*> > & a_GlobalUniqueS
     if (proc_zero())
       printf("Read npts=%i, made %i point moment tensor sources, nu1=%i, nu2=%i, nu3=%i\n", 
 	     npts, nSources, nu1, nu2, nu3);
+    if (proc_zero() && nskip_zero_slip > 0)
+      printf("Skipped %i rupture points with zero slip-velocity integral in u1.\n", nskip_zero_slip);
     
     fclose(fd);
   }

--- a/src/parseInputFile.C
+++ b/src/parseInputFile.C
@@ -6350,7 +6350,7 @@ void EW::processRupture(char* buffer, vector<vector<Source*> > & a_GlobalUniqueS
            skip_zero_slip_point = true;
            if( proc_zero() && nskip_zero_slip <= 10 )
            {
-              printf("WARNING: skipping rupture point #%i because dt*sum(slip_vel)=%e [m], slip1=%e [m]\n",
+              printf("WARNING: skipping rupture point #%i because dt*sum(slip_vel)=%e [m], total slip (from header)=%e [m]\n",
                      pts+1, slip_sum, slip_m);
            }
         }

--- a/src/parseInputFile.C
+++ b/src/parseInputFile.C
@@ -6343,32 +6343,34 @@ void EW::processRupture(char* buffer, vector<vector<Source*> > & a_GlobalUniqueS
            printf("INFO: SRF file: dt*sum(slip_vel)=%e [m], total slip (from header)=%e [m]\n", slip_sum, slip_m);
         }
         float_sw4 slip_sum_tol = 1e-12;
+        bool skip_zero_slip_point = false;
         if( slip_sum > -slip_sum_tol && slip_sum < slip_sum_tol )
         {
            nskip_zero_slip++;
+           skip_zero_slip_point = true;
            if( proc_zero() && nskip_zero_slip <= 10 )
            {
               printf("WARNING: skipping rupture point #%i because dt*sum(slip_vel)=%e [m], slip1=%e [m]\n",
                      pts+1, slip_sum, slip_m);
            }
-           for (int i=1; i<=nt1dim+1; i++)
-              par[i] = 0;
-           slip_sum = 1;
         }
 // scale time series to sum to integrate to one        
-	for (int i=1; i<=nt1dim+1; i++)
+	if( !skip_zero_slip_point )
 	{
-           par[i] /= slip_sum;
-	}
-        if (proc_zero() && mVerbose >= 2)
-        {
-           slip_sum=0;
-           for (int i=1; i<=nt1dim+1; i++)
-           {
-              slip_sum += par[i];
-           }
-           slip_sum *=dt;
-           printf("INFO: SRF file: After scaling time series: dt*sum(par)=%e [m]\n", slip_sum);
+	  for (int i=1; i<=nt1dim+1; i++)
+	  {
+             par[i] /= slip_sum;
+	  }
+          if (proc_zero() && mVerbose >= 2)
+          {
+             slip_sum=0;
+             for (int i=1; i<=nt1dim+1; i++)
+             {
+                slip_sum += par[i];
+             }
+             slip_sum *=dt;
+             printf("INFO: SRF file: After scaling time series: dt*sum(par)=%e [m]\n", slip_sum);
+          }
         }
 //done scaling        
         
@@ -6446,7 +6448,7 @@ void EW::processRupture(char* buffer, vector<vector<Source*> > & a_GlobalUniqueS
 	  if (m_myRank == 0)
 	    cout << sourceposerr.str();
 	}
-	else if( event_is_in_proc(event) )
+	else if( !skip_zero_slip_point && event_is_in_proc(event) )
 	{
            event = global_to_local_event(event);
            sourcePtr = new Source(this, freq, t0, x, y, z, mxx, mxy, mxz, myy, myz, mzz,

--- a/src/readhdf5.C
+++ b/src/readhdf5.C
@@ -778,32 +778,34 @@ void readRuptureHDF5(char *fname, vector<vector<Source*> > & a_GlobalUniqueSourc
          printf("INFO: SRF file: dt*sum(slip_vel)=%e [m], total slip (from header)=%e [m]\n", slip_sum, slip_m);
       }
       float_sw4 slip_sum_tol = 1e-12;
+      bool skip_zero_slip_point = false;
       if( slip_sum > -slip_sum_tol && slip_sum < slip_sum_tol )
       {
         nskip_zero_slip++;
+        skip_zero_slip_point = true;
         if( world_rank == 0 && nskip_zero_slip <= 10 )
         {
           printf("WARNING: skipping rupture point #%i because dt*sum(slip_vel)=%e [m], slip1=%e [m]\n",
                  pts+1, slip_sum, slip_m);
         }
+      }
+      // scale time series to sum to integrate to one
+      if( !skip_zero_slip_point )
+      {
         for (int i=1; i<=nt1dim+1; i++)
-          par[i] = 0;
-        slip_sum = 1;
-      }
-      // scale time series to sum to integrate to one        
-      for (int i=1; i<=nt1dim+1; i++)
-      {
-         par[i] /= slip_sum;
-      }
-      if (world_rank == 0 && mVerbose >= 2)
-      {
-         slip_sum=0;
-         for (int i=1; i<=nt1dim+1; i++)
-         {
-            slip_sum += par[i];
-         }
-         slip_sum *=dt;
-         printf("INFO: SRF file: After scaling time series: dt*sum(par)=%e [m]\n", slip_sum);
+        {
+           par[i] /= slip_sum;
+        }
+        if (world_rank == 0 && mVerbose >= 2)
+        {
+           slip_sum=0;
+           for (int i=1; i<=nt1dim+1; i++)
+           {
+              slip_sum += par[i];
+           }
+           slip_sum *=dt;
+           printf("INFO: SRF file: After scaling time series: dt*sum(par)=%e [m]\n", slip_sum);
+        }
       }
       //done scaling        
       
@@ -881,7 +883,7 @@ void readRuptureHDF5(char *fname, vector<vector<Source*> > & a_GlobalUniqueSourc
         if (world_rank == 0)
           cout << sourceposerr.str();
       }
-      else
+      else if( !skip_zero_slip_point )
       {
         sourcePtr = new Source(ew, freq, t0, x, y, z, mxx, mxy, mxz, myy, myz, mzz,
                                tDep, formstring, topodepth, ncyc, par, npar, ipar, nipar, true ); // true is correctStrengthForMu

--- a/src/readhdf5.C
+++ b/src/readhdf5.C
@@ -569,7 +569,7 @@ void readRuptureHDF5(char *fname, vector<vector<Source*> > & a_GlobalUniqueSourc
   int npts = 0, nseg = 0, nsr1 = 0;
   hsize_t dims;
   double rVersion;
-  int nSources=0, nu1=0, nu2=0, nu3=0;
+  int nSources=0, nu1=0, nu2=0, nu3=0, nskip_zero_slip=0;
 
   stime = MPI_Wtime();
   // Only rank 0 reads data, then broadcast to all other processes
@@ -777,6 +777,19 @@ void readRuptureHDF5(char *fname, vector<vector<Source*> > & a_GlobalUniqueSourc
       {
          printf("INFO: SRF file: dt*sum(slip_vel)=%e [m], total slip (from header)=%e [m]\n", slip_sum, slip_m);
       }
+      float_sw4 slip_sum_tol = 1e-12;
+      if( slip_sum > -slip_sum_tol && slip_sum < slip_sum_tol )
+      {
+        nskip_zero_slip++;
+        if( world_rank == 0 && nskip_zero_slip <= 10 )
+        {
+          printf("WARNING: skipping rupture point #%i because dt*sum(slip_vel)=%e [m], slip1=%e [m]\n",
+                 pts+1, slip_sum, slip_m);
+        }
+        for (int i=1; i<=nt1dim+1; i++)
+          par[i] = 0;
+        slip_sum = 1;
+      }
       // scale time series to sum to integrate to one        
       for (int i=1; i<=nt1dim+1; i++)
       {
@@ -911,6 +924,8 @@ void readRuptureHDF5(char *fname, vector<vector<Source*> > & a_GlobalUniqueSourc
   } // end for all sources
   if (world_rank == 0)
     printf("Read npts=%i, made %i point moment tensor sources, nu1=%i, nu2=%i, nu3=%i\n", npts, nSources, nu1, nu2, nu3);
+  if (world_rank == 0 && nskip_zero_slip > 0)
+    printf("Skipped %i rupture points with zero slip-velocity integral in u1.\n", nskip_zero_slip);
 
   etime = MPI_Wtime();
   if (is_debug && world_rank == 0) 

--- a/src/readhdf5.C
+++ b/src/readhdf5.C
@@ -785,7 +785,7 @@ void readRuptureHDF5(char *fname, vector<vector<Source*> > & a_GlobalUniqueSourc
         skip_zero_slip_point = true;
         if( world_rank == 0 && nskip_zero_slip <= 10 )
         {
-          printf("WARNING: skipping rupture point #%i because dt*sum(slip_vel)=%e [m], slip1=%e [m]\n",
+          printf("WARNING: skipping rupture point #%i because dt*sum(slip_vel)=%e [m], total slip (from header)=%e [m]\n",
                  pts+1, slip_sum, slip_m);
         }
       }

--- a/src/sachdf5.C
+++ b/src/sachdf5.C
@@ -353,9 +353,11 @@ int createTimeSeriesHDF5File(vector<TimeSeries*> & TimeSeries, int totalSteps, f
 
   fapl = H5Pcreate(H5P_FILE_ACCESS);
   H5Pset_alignment(fapl, 32767, alignment);
+  H5Pset_fapl_mpio(fapl, MPI_COMM_SELF, MPI_INFO_NULL);
   fid = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
   if (fid < 0) {
     printf("Error: H5Fcreate failed\n");
+    H5Pclose(fapl);
     return -1;
   }
   H5Pclose(fapl);
@@ -571,6 +573,7 @@ int createTimeSeriesHDF5File(vector<TimeSeries*> & TimeSeries, int totalSteps, f
   H5Sclose(attr_space1);
   H5Sclose(attr_space3);
   H5Sclose(attr_space4);
+  H5Fflush(fid, H5F_SCOPE_GLOBAL);
   H5Fclose(fid);
 
   elapsed_time = MPI_Wtime() - start_time;

--- a/src/solve.C
+++ b/src/solve.C
@@ -40,6 +40,9 @@
 #include "CurvilinearInterface2.h"
 #include "SfileOutput.h"
 
+#ifdef USE_HDF5
+#include <unistd.h>
+#endif
 
 void curvilinear4sgwind( int, int, int, int, int, int, int, int, float_sw4*, float_sw4*, float_sw4*,
                          float_sw4*, float_sw4*, float_sw4*, int*, float_sw4*, float_sw4*, float_sw4*, float_sw4*,
@@ -511,6 +514,22 @@ void EW::solve( vector<Source*> & a_Sources, vector<TimeSeries*> & a_TimeSeries,
       a_TimeSeries[tsi]->resetHDF5file();
     if(m_myRank == 0 && !m_check_point->do_restart()) 
       createTimeSeriesHDF5File(a_TimeSeries, mNumberOfTimeSteps[event]+1, mDt, "");
+    MPI_Barrier(m_1d_communicator);
+    hid_t fid = 0;
+    const int max_open_attempts = 10;
+    for (int attempt = 0; attempt < max_open_attempts && fid <= 0; attempt++)
+    {
+      H5E_BEGIN_TRY
+      {
+        fid = a_TimeSeries[0]->openHDF5File("", true);
+      }
+      H5E_END_TRY
+      if (fid <= 0 && attempt + 1 < max_open_attempts)
+        sleep(1);
+    }
+    CHECK_INPUT(fid > 0,
+                "Could not open receiver HDF5 file on rank " << m_myRank <<
+                " after " << max_open_attempts << " attempts");
     MPI_Barrier(m_1d_communicator);
   }
 #endif


### PR DESCRIPTION
- Skip SRF sources with slip_sum=0 and print out the skipped messages
- Write out "Coarsest horizontal grid spacing" for sfile output
- Removed unnecessary H5Gflush that may cause issues in some systems
- Fix NumPy int issue in pytest
- Fix some issues with GMG reader using hard-coded values